### PR TITLE
docker: apply Debian security patches at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ RUN pip install --no-cache-dir --target /wheels --no-deps .
 # ---------------------------------------------------------------------------
 FROM python:3.14-slim@sha256:1697e8e8d39bf168e177ac6b5fdab6df86d81cfc24dae17dfb96cfc3ef76b4dd AS runtime
 
+# Apply Debian security patches on top of the pinned base. Keeps the digest
+# pin for reproducibility while picking up CVE fixes between base rebuilds
+# (libcap2 CVE-2026-4878, libsystemd0/libudev1 CVE-2026-29111, etc).
+RUN apt-get update && apt-get -y upgrade && rm -rf /var/lib/apt/lists/*
+
 # MCP Registry ownership-verification label. The value MUST match the
 # `name` field in server.json so the registry can verify the publisher
 # controls this image. See:


### PR DESCRIPTION
## Summary

Trivy in CI has been failing on every PR (incl. all open Dependabot bumps) because the pinned `python:3.14-slim` base image carries HIGH-severity Debian CVEs that have fixes available but haven't yet rolled into the upstream digest:

- `libcap2` — CVE-2026-4878 (fix: `1:2.75-10+deb13u1`)
- `libsystemd0` / `libudev1` — CVE-2026-29111 (fix: `257.13-1~deb13u1`)

Trivy is already configured with `ignore-unfixed: true`, so it correctly does not suppress these (the fixes exist; we just hadn't applied them).

## Fix

Add a single `apt-get update && apt-get -y upgrade` to the runtime stage. This layers Debian security patches on top of the pinned base image. We keep the digest pin (reproducibility) and pick up urgent CVE fixes between upstream rebuilds.

Same pattern will be applied to phish-vault, anthropic-tracker, anthropic-tracker-mcp, and open-setlist-stash.

## Test plan

- [ ] CI passes (build-image + trivy-scan both green)
- [ ] Trivy image scan reports 0 HIGH/CRITICAL OS-level findings