### PR TITLE
v0.9.0: bearer-token auth on HTTP transport (secure by default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,4 +44,29 @@ MCP_PORT=3714
 LOG_LEVEL=INFO
 LOG_FORMAT=json
 
+# ---------------------------------------------------------------------------
+# HTTP transport authentication (v0.9.0+)
+# ---------------------------------------------------------------------------
+# Bearer tokens for clients connecting over streamable-http. Comma-separated.
+# Each entry is either a bare token (auto-assigned client_id 'client-0',
+# 'client-1', ...) or a 'name:token' pair for named clients. The 'name'
+# shows up in the audit log so you can trace each call back to its caller.
+#
+# Generate a token:
+#   openssl rand -hex 32
+#
+# Example:
+#   MCP_UNIFI_AUTH_TOKENS=claude:7f3a...,n8n:c812...,homeassistant:a4d9...
+#
+# Clients send: Authorization: Bearer <token>
+#
+# Ignored on stdio transport (parent process owns the security boundary).
+MCP_UNIFI_AUTH_TOKENS=
+
+# Secure-by-default. If True (default), the server refuses to start on HTTP
+# transport without tokens configured above. Set to false ONLY if the server
+# is on a single-host trusted boundary (e.g. localhost-only with a private
+# network namespace). Even then, prefer setting at least one token.
+MCP_UNIFI_AUTH_REQUIRED=true
+
 TZ=UTC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-05-27
+
+> **Bearer-token authentication on HTTP transport, secure by default.**
+> Anyone running v0.8.0 over streamable-http MUST either configure
+> ``MCP_UNIFI_AUTH_TOKENS`` or explicitly opt out with
+> ``MCP_UNIFI_AUTH_REQUIRED=false`` before upgrading. Stdio is unaffected.
+
+### Added
+
+- **HTTP transport authentication.** Streamable-HTTP requests are now
+  authenticated via the ``Authorization: Bearer <token>`` header. Tokens
+  are configured via the ``MCP_UNIFI_AUTH_TOKENS`` env var as a CSV of
+  either bare tokens (auto-assigned client_id ``client-0``,
+  ``client-1``, ...) or ``name:token`` pairs (named clients show up in
+  the audit log by name). Backed by FastMCP's ``StaticTokenVerifier``.
+- **Per-call authenticated client_id in the audit log.** Every entry now
+  carries a ``client_id`` field. Set to the authenticated client's id on
+  HTTP transport, ``null`` on stdio or when auth is disabled. Old logs
+  without the field continue to parse via the dataclass default — no
+  schema bump.
+
+### Changed
+
+- **BREAKING (HTTP transport only).** ``build_server`` raises at startup
+  if ``mcp_transport=streamable-http`` and ``auth_required=true`` (the
+  default) and no tokens are configured. Migration: generate a token
+  with ``openssl rand -hex 32``, set ``MCP_UNIFI_AUTH_TOKENS=<token>``,
+  update each client config to send the ``Authorization`` header. Stdio
+  transport is unaffected — the parent process owns the security
+  boundary, so layering bearer auth there would be theatre.
+- New env vars: ``MCP_UNIFI_AUTH_TOKENS`` (default empty),
+  ``MCP_UNIFI_AUTH_REQUIRED`` (default ``true``). The latter is an
+  escape hatch for single-host trusted-boundary deployments; flipping
+  it logs a loud WARNING at boot.
+
+### Internal
+
+- ``Settings.auth_token_map`` parses the CSV into the dict shape FastMCP
+  expects, rejecting duplicate tokens and empty values at config-load
+  time rather than first-request time.
+- ``@audited`` decorator pulls ``client_id`` from
+  ``fastmcp.server.dependencies.get_access_token()`` per call. Falls
+  back to ``None`` outside an HTTP request scope (stdio, direct
+  ``server.call_tool`` invocations, tests).
+
 ## [0.8.0] - 2026-05-26
 
 > **UCG-Fiber security/VPN coverage.** Seven new Network tools for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,8 +23,12 @@ supported version is whatever is tagged latest on the
 ## Threat model
 
 mcp-unifi is designed to run on a trusted LAN and talk to a single self-hosted
-UniFi gateway. The server itself does **not** authenticate incoming MCP
-connections; access control is the responsibility of the host network.
+UniFi gateway. As of v0.9.0, the HTTP transport authenticates every request
+with a bearer token (`Authorization: Bearer <token>`); the server refuses to
+start without tokens by default. Stdio transport stays unauthenticated by
+design — the parent process owns the security boundary. Even with bearer
+auth on, treat the network as defence in depth: run on a trusted segment,
+behind a Tailscale ACL, etc.
 
 The container:
 

--- a/charts/mcp-unifi/templates/deployment.yaml
+++ b/charts/mcp-unifi/templates/deployment.yaml
@@ -53,12 +53,22 @@ spec:
               value: {{ .Values.unifi.verifySSL | quote }}
             - name: MCP_UNIFI_MODULES_ENABLED
               value: {{ .Values.modulesEnabled | quote }}
+            - name: MCP_UNIFI_AUTH_REQUIRED
+              value: {{ .Values.auth.required | quote }}
             {{- if or .Values.existingSecret .Values.unifi.apiKey }}
             - name: UNIFI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "mcp-unifi.secretName" . }}
                   key: UNIFI_API_KEY
+            {{- end }}
+            {{- if or .Values.existingSecret .Values.auth.tokens }}
+            - name: MCP_UNIFI_AUTH_TOKENS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-unifi.secretName" . }}
+                  key: MCP_UNIFI_AUTH_TOKENS
+                  optional: {{ ternary "true" "false" (not .Values.auth.tokens) }}
             {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:

--- a/charts/mcp-unifi/templates/secret.yaml
+++ b/charts/mcp-unifi/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.existingSecret) .Values.unifi.apiKey }}
+{{- if and (not .Values.existingSecret) (or .Values.unifi.apiKey .Values.auth.tokens) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +7,10 @@ metadata:
     {{- include "mcp-unifi.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.unifi.apiKey }}
   UNIFI_API_KEY: {{ .Values.unifi.apiKey | quote }}
+  {{- end }}
+  {{- if .Values.auth.tokens }}
+  MCP_UNIFI_AUTH_TOKENS: {{ .Values.auth.tokens | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/mcp-unifi/values.yaml
+++ b/charts/mcp-unifi/values.yaml
@@ -27,6 +27,20 @@ existingSecret: ""
 
 modulesEnabled: "network"
 
+# HTTP transport authentication (v0.9.0+).
+# `tokens` is a comma-separated list of bearer tokens. Each entry is either a
+# bare token (auto-assigned client_id `client-N`) or a `name:token` pair.
+# Generate one with: `openssl rand -hex 32`.
+#
+# Secure by default: with `required: true` (the default), the pod fails to
+# start if `tokens` is empty AND no `existingSecret` carries
+# MCP_UNIFI_AUTH_TOKENS. Set `required: false` only on a trusted, isolated
+# segment — every connected client gets admin-equivalent access to the
+# controller.
+auth:
+  tokens: ""
+  required: true
+
 service:
   type: ClusterIP
   port: 3714

--- a/docs/site/src/content/docs/guides/auth.md
+++ b/docs/site/src/content/docs/guides/auth.md
@@ -1,0 +1,98 @@
+---
+draft: false
+title: Authentication
+description: Bearer-token auth on the streamable-HTTP transport — setup, client config, audit log.
+---
+
+Starting in **v0.9.0**, the HTTP transport authenticates every incoming MCP request with an `Authorization: Bearer <token>` header. The server is **secure by default**: it refuses to start over `streamable-http` without tokens configured. Stdio transport is unaffected — the parent process owns the security boundary there, so adding bearer auth would be theatre.
+
+## Why this changed
+
+mcp-unifi exposes 57 Network tools and 11 Protect tools. Many are destructive: delete a VLAN, rewrite a firewall rule, disable Threat Management, block a client. Before v0.9.0 the server trusted the LAN, which meant a single compromised IoT device on the same network had admin-equivalent access to the controller. v0.9.0 closes that gap.
+
+## Generate a token
+
+```bash
+openssl rand -hex 32
+```
+
+Use one token per client (Claude Code, n8n, Home Assistant, etc.) so you can revoke one without rotating all.
+
+## Configure the server
+
+Set `MCP_UNIFI_AUTH_TOKENS` as a comma-separated list. Each entry is either:
+
+- a **bare token** (auto-assigned client_id `client-0`, `client-1`, ...)
+- a **`name:token` pair** for named clients (recommended — the name shows up in the audit log)
+
+```env
+MCP_UNIFI_AUTH_TOKENS=claude:7f3a...,n8n:c812...,homeassistant:a4d9...
+MCP_UNIFI_AUTH_REQUIRED=true
+```
+
+On boot, the server logs the configured client_ids (never the tokens) and starts. Without tokens and with `MCP_UNIFI_AUTH_REQUIRED=true`, the server raises at startup with a clear error.
+
+## Configure the client
+
+### Claude Code
+
+Add the `Authorization` header in your MCP server config:
+
+```json
+{
+  "mcpServers": {
+    "unifi": {
+      "type": "http",
+      "url": "http://nix1:3714/mcp",
+      "headers": {
+        "Authorization": "Bearer 7f3a..."
+      }
+    }
+  }
+}
+```
+
+### Generic HTTP client
+
+Every request to `/mcp` must carry:
+
+```
+Authorization: Bearer <token>
+```
+
+Missing or wrong → 401.
+
+## Opting out (single-host trusted boundary only)
+
+If the server is bound to `127.0.0.1` and only reachable from the same host inside a private network namespace, you can disable auth:
+
+```env
+MCP_UNIFI_AUTH_REQUIRED=false
+```
+
+The server boots with a loud `WARNING` log line every time. **Don't do this on a multi-host LAN, a tailnet, or anywhere a guest network could reach the port.**
+
+## Audit log
+
+Every tool call records the authenticated `client_id` in the JSONL audit log:
+
+```json
+{
+  "ts": "2026-05-27T18:42:11.000Z",
+  "controller": "default",
+  "tool": "delete_firewall_rule",
+  "client_id": "n8n",
+  "args": {...},
+  "success": true,
+  "latency_ms": 142.3
+}
+```
+
+`client_id` is `null` on stdio or when auth is disabled. Older entries from v0.8.0 and earlier omit the field entirely; replay tooling tolerates both shapes (no schema version bump — the field defaults to `null` when missing).
+
+## What's still out of scope
+
+- **Per-tool scopes**: every authenticated client can call every tool. Per-client RBAC is a v1.x decision.
+- **Token rotation API**: rotate by editing the env var and restarting. No live rotation endpoint.
+- **OAuth flows**: out of scope. The static-token model fits homelab single-admin use; if you need OAuth, front mcp-unifi with an authenticating reverse proxy (Authelia, Caddy + auth_request, etc.) and keep `MCP_UNIFI_AUTH_REQUIRED=false`.
+- **Rate limiting**: not implemented.

--- a/docs/site/src/content/docs/guides/security.md
+++ b/docs/site/src/content/docs/guides/security.md
@@ -8,7 +8,7 @@ mcp-unifi is designed to run on a trusted home or homelab LAN, behind your exist
 
 ## Threat model
 
-- **Trusted boundary**: the MCP server is **not authenticated**. Anyone who can reach `http://<host>:3714/mcp` can call every tool. Put it on a trusted LAN, behind a reverse proxy with auth, or behind a Tailscale ACL.
+- **Trusted boundary**: starting in v0.9.0, the HTTP transport requires a bearer token on every request (see the [Authentication guide](/mcp-unifi/guides/auth/)). The server refuses to start without tokens by default. Stdio transport remains unauthenticated by design — the parent process owns the security boundary. Even with auth on, run the server inside a trusted LAN segment or behind a Tailscale ACL: defence in depth.
 - **Local-network only**: the server talks to your UniFi gateway over the **local API** (X-API-Key header to `https://<gateway>/proxy/network/...`). It does not call out to any Ubiquiti cloud endpoint, does not require a UI account, and does not require Site Manager / Cloud Console enrollment.
 - **Self-signed gateway certs**: most home gateways present a self-signed certificate. `UNIFI_VERIFY_SSL` defaults to `false` for that reason. Set it to `true` once you've installed a real certificate.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.8.0"
+version = "0.9.0"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scripts/dump_tool_schemas.py
+++ b/scripts/dump_tool_schemas.py
@@ -43,7 +43,9 @@ def _serialise_tool(tool: Any) -> dict[str, Any]:
 
 
 async def _collect() -> list[dict[str, Any]]:
-    settings = Settings(stub_mode=True, log_format="text")
+    # stdio transport bypasses the HTTP auth gate; this introspection-only
+    # script never serves traffic.
+    settings = Settings(stub_mode=True, log_format="text", mcp_transport="stdio")
     server = build_server(settings)
     tools_obj = await server.list_tools()
     tools_iter = tools_obj.values() if isinstance(tools_obj, dict) else tools_obj

--- a/scripts/generate_tool_manifest.py
+++ b/scripts/generate_tool_manifest.py
@@ -106,7 +106,9 @@ def _serialise_tool(tool: Any) -> dict[str, Any]:
 
 
 async def _collect_tools() -> list[dict[str, Any]]:
-    settings = Settings(stub_mode=True, log_format="text")
+    # stdio transport bypasses the HTTP auth gate; this generator only
+    # introspects tool metadata and never serves traffic.
+    settings = Settings(stub_mode=True, log_format="text", mcp_transport="stdio")
     server = build_server(settings)
     tools_obj = await server.list_tools()
     tools_iter = tools_obj.values() if isinstance(tools_obj, dict) else tools_obj

--- a/src/mcp_unifi/audit.py
+++ b/src/mcp_unifi/audit.py
@@ -108,6 +108,11 @@ class AuditEvent:
     success: bool
     latency_ms: float
     error: str | None = None
+    #: The authenticated client_id that issued this call, when HTTP transport
+    #: auth is enabled (v0.9.0+). ``None`` on stdio or when auth is disabled.
+    #: Replay tools tolerate older logs missing this field via the dataclass
+    #: default, so schema stays at "1".
+    client_id: str | None = None
     # Schema version. Bump when the envelope shape changes so replay can
     # reject incompatible logs cleanly.
     schema: str = field(default="1")
@@ -248,6 +253,7 @@ class AuditLog:
         success: bool,
         latency_ms: float,
         error: str | None = None,
+        client_id: str | None = None,
     ) -> AuditEvent:
         """Record a single tool invocation.
 
@@ -268,6 +274,7 @@ class AuditLog:
             success=success,
             latency_ms=round(latency_ms, 3),
             error=error,
+            client_id=client_id,
         )
         async with self._lock:
             try:

--- a/src/mcp_unifi/config.py
+++ b/src/mcp_unifi/config.py
@@ -130,6 +130,60 @@ class Settings(BaseSettings):
     )
 
     # ------------------------------------------------------------------
+    # HTTP transport authentication (v0.9.0+)
+    # ------------------------------------------------------------------
+    auth_tokens: str = Field(
+        default="",
+        description=(
+            "Bearer tokens for HTTP transport. Comma-separated. Each entry "
+            "is either a bare token (assigned synthetic client_id 'client-N') "
+            "or a 'client_id:token' pair for named clients. Ignored on stdio."
+        ),
+    )
+    auth_required: bool = Field(
+        default=True,
+        description=(
+            "If True (default), HTTP transport refuses to start without "
+            "auth_tokens. Set False to opt out (NOT RECOMMENDED for any "
+            "deployment beyond a single-host trusted boundary). Ignored on stdio."
+        ),
+    )
+
+    @property
+    def auth_token_map(self) -> dict[str, dict[str, Any]]:
+        """Parse ``auth_tokens`` into the dict shape FastMCP's StaticTokenVerifier expects.
+
+        Returns ``{token: {"client_id": str, "scopes": []}}``. Empty if no
+        tokens configured. Each entry in the CSV is either a bare token
+        (assigned ``client-0``, ``client-1``, ...) or a ``name:token`` pair
+        (then ``client_id`` is the name). Used by ``build_server`` to wire
+        the auth provider; also surfaced for tests.
+        """
+        raw = self.auth_tokens.strip()
+        if not raw:
+            return {}
+        out: dict[str, dict[str, Any]] = {}
+        for idx, item in enumerate(raw.split(",")):
+            item = item.strip()
+            if not item:
+                continue
+            if ":" in item:
+                client_id, _, token = item.partition(":")
+                client_id = client_id.strip()
+                token = token.strip()
+            else:
+                client_id, token = f"client-{idx}", item
+            if not token:
+                raise ValueError(f"MCP_UNIFI_AUTH_TOKENS entry {idx} is missing a token value")
+            if token in out:
+                raise ValueError(
+                    f"MCP_UNIFI_AUTH_TOKENS entry {idx} reuses a token already "
+                    f"assigned to client_id={out[token]['client_id']!r}"
+                )
+            out[token] = {"client_id": client_id, "scopes": []}
+        return out
+
+    # ------------------------------------------------------------------
     # Validation
     # ------------------------------------------------------------------
 
@@ -234,6 +288,8 @@ class Settings(BaseSettings):
             "mcp_port": self.mcp_port,
             "log_level": self.log_level,
             "log_format": self.log_format,
+            "auth_required": self.auth_required,
+            "auth_client_ids": sorted(meta["client_id"] for meta in self.auth_token_map.values()),
         }
 
 

--- a/src/mcp_unifi/modules/_audit.py
+++ b/src/mcp_unifi/modules/_audit.py
@@ -36,6 +36,22 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+def _current_client_id() -> str | None:
+    """Return the authenticated client_id for the current request, or None.
+
+    Falls back to None on stdio, in tests without an MCP context, or when
+    auth is disabled. Never raises — audit must work even if the FastMCP
+    dependency surface changes shape across versions.
+    """
+    try:
+        from fastmcp.server.dependencies import get_access_token
+
+        token = get_access_token()
+    except Exception:
+        return None
+    return token.client_id if token is not None else None
+
+
 def _coerce_result(value: Any) -> Any:
     """Best-effort decode of a tool's return value into a structured object.
 
@@ -77,6 +93,7 @@ def audited(
                 audit_args["_positional"] = list(args)
 
             controller = str(kwargs.get("controller", "default"))
+            client_id = _current_client_id()
             log = audit.get_audit_log()
 
             start = time.perf_counter()
@@ -92,6 +109,7 @@ def audited(
                     success=False,
                     latency_ms=latency_ms,
                     error=str(exc),
+                    client_id=client_id,
                 )
                 raise
 
@@ -103,6 +121,7 @@ def audited(
                 result=_coerce_result(result),
                 success=True,
                 latency_ms=latency_ms,
+                client_id=client_id,
             )
             return result
 

--- a/src/mcp_unifi/server.py
+++ b/src/mcp_unifi/server.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 
 from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
@@ -93,7 +94,8 @@ def build_server(
         protect_real_overrides=protect_real_overrides,
     )
 
-    mcp = FastMCP("UniFi")
+    auth_provider = _build_auth_provider(settings)
+    mcp = FastMCP("UniFi", auth=auth_provider)
 
     @mcp.custom_route("/health", methods=["GET"])
     async def health(_request: Request) -> PlainTextResponse:
@@ -106,6 +108,40 @@ def build_server(
 
     register_modules(mcp, settings, registry)
     return mcp
+
+
+def _build_auth_provider(settings: Settings) -> StaticTokenVerifier | None:
+    """Construct the FastMCP auth provider for the active transport.
+
+    Returns ``None`` on stdio (parent process owns the security boundary, so
+    layering bearer-token auth on top is theatre). On HTTP transport: if
+    tokens are configured, wraps them in :class:`StaticTokenVerifier`. If no
+    tokens and ``auth_required=True`` (the default), raises so the server
+    refuses to start unauthenticated. The escape hatch is
+    ``MCP_UNIFI_AUTH_REQUIRED=false`` for the single-host trusted-boundary case.
+    """
+    if settings.mcp_transport == "stdio":
+        return None
+    tokens = settings.auth_token_map
+    if not tokens:
+        if settings.auth_required:
+            raise ValueError(
+                "HTTP transport requires MCP_UNIFI_AUTH_TOKENS. Generate a "
+                "token with `openssl rand -hex 32` and set the env var. To "
+                "opt out (NOT RECOMMENDED beyond a single-host trusted "
+                "boundary), set MCP_UNIFI_AUTH_REQUIRED=false."
+            )
+        logger.warning(
+            "HTTP transport running WITHOUT authentication "
+            "(MCP_UNIFI_AUTH_REQUIRED=false). Every connected client has "
+            "admin-equivalent access to the UniFi controller."
+        )
+        return None
+    logger.info(
+        "HTTP transport authentication enabled",
+        extra={"client_ids": sorted(meta["client_id"] for meta in tokens.values())},
+    )
+    return StaticTokenVerifier(tokens=tokens)
 
 
 def main() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,13 +55,18 @@ def stub_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[Settings]:
         "IOT_SUBNET_TEMPLATE",
         "IOT_DHCP_START_OFFSET",
         "IOT_DHCP_STOP_OFFSET",
+        "MCP_TRANSPORT",
         "MCP_HOST",
         "MCP_PORT",
         "LOG_LEVEL",
         "LOG_FORMAT",
+        "MCP_UNIFI_AUTH_TOKENS",
+        "MCP_UNIFI_AUTH_REQUIRED",
     ):
         monkeypatch.delenv(var, raising=False)
-    yield Settings(stub_mode=True, log_format="text")
+    # auth_required defaults to True in v0.9.0+; tests that don't exercise
+    # auth want a server that boots cleanly without tokens.
+    yield Settings(stub_mode=True, log_format="text", auth_required=False)
 
 
 @pytest.fixture
@@ -77,10 +82,13 @@ def real_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[Settings]:
         "IOT_SUBNET_TEMPLATE",
         "IOT_DHCP_START_OFFSET",
         "IOT_DHCP_STOP_OFFSET",
+        "MCP_TRANSPORT",
         "MCP_HOST",
         "MCP_PORT",
         "LOG_LEVEL",
         "LOG_FORMAT",
+        "MCP_UNIFI_AUTH_TOKENS",
+        "MCP_UNIFI_AUTH_REQUIRED",
     ):
         monkeypatch.delenv(var, raising=False)
     yield Settings(
@@ -90,4 +98,5 @@ def real_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[Settings]:
         unifi_site="default",
         unifi_api_key="test-api-key-1234",
         log_format="text",
+        auth_required=False,
     )

--- a/tests/network/test_multi_site.py
+++ b/tests/network/test_multi_site.py
@@ -113,6 +113,8 @@ async def test_legacy_single_controller_env_still_works(
         "UNIFI_SITE",
         "UNIFI_VERIFY_SSL",
         "MCP_UNIFI_CONTROLLERS_FILE",
+        "MCP_UNIFI_AUTH_TOKENS",
+        "MCP_UNIFI_AUTH_REQUIRED",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -120,7 +122,7 @@ async def test_legacy_single_controller_env_still_works(
     monkeypatch.setenv("UNIFI_API_KEY", "legacy-key-from-env")
     monkeypatch.setenv("STUB_MODE", "true")
 
-    settings = Settings(log_format="text")
+    settings = Settings(log_format="text", auth_required=False)
     assert len(settings.controllers) == 1
     assert settings.controllers[0].name == "default"
     assert settings.controllers[0].host == "legacy.example.com"

--- a/tests/protect/conftest.py
+++ b/tests/protect/conftest.py
@@ -49,15 +49,18 @@ def protect_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[Settings]:
         "IOT_SUBNET_TEMPLATE",
         "IOT_DHCP_START_OFFSET",
         "IOT_DHCP_STOP_OFFSET",
+        "MCP_TRANSPORT",
         "MCP_HOST",
         "MCP_PORT",
         "LOG_LEVEL",
         "LOG_FORMAT",
         "MCP_UNIFI_CONTROLLERS_FILE",
+        "MCP_UNIFI_AUTH_TOKENS",
+        "MCP_UNIFI_AUTH_REQUIRED",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("MCP_UNIFI_MODULES_ENABLED", "protect")
-    yield Settings(stub_mode=True, log_format="text")
+    yield Settings(stub_mode=True, log_format="text", auth_required=False)
 
 
 @pytest.fixture

--- a/tests/protect/test_real_mode.py
+++ b/tests/protect/test_real_mode.py
@@ -35,17 +35,21 @@ def real_protect_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[Settings]
         "UNIFI_PORT",
         "UNIFI_SITE",
         "UNIFI_VERIFY_SSL",
+        "MCP_TRANSPORT",
         "MCP_HOST",
         "MCP_PORT",
         "LOG_LEVEL",
         "LOG_FORMAT",
         "MCP_UNIFI_CONTROLLERS_FILE",
+        "MCP_UNIFI_AUTH_TOKENS",
+        "MCP_UNIFI_AUTH_REQUIRED",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("MCP_UNIFI_MODULES_ENABLED", "protect")
     yield Settings(
         stub_mode=False,
         log_format="text",
+        auth_required=False,
         controllers=[
             ControllerConfig(
                 name="default",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,189 @@
+"""HTTP transport authentication (v0.9.0+).
+
+Covers:
+
+* Settings parses ``MCP_UNIFI_AUTH_TOKENS`` into the StaticTokenVerifier-shape
+  dict for both bare and named (``client_id:token``) entries.
+* ``build_server`` refuses to construct an HTTP transport without tokens when
+  ``auth_required=True``.
+* ``build_server`` issues a warning (but boots) when ``auth_required=False``.
+* Stdio transport is exempt — no tokens needed, no auth provider wired.
+* When tokens are present, FastMCP receives a ``StaticTokenVerifier`` with
+  matching client_ids.
+* The ``@audited`` decorator carries through ``client_id=None`` when no auth
+  context is active (the default for direct ``call_tool`` invocations).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+from mcp_unifi.audit import AuditLog, FileSink, set_audit_log
+from mcp_unifi.clients.stubs import StubState
+from mcp_unifi.config import Settings
+from mcp_unifi.server import _build_auth_provider, build_server
+
+# ---------------------------------------------------------------------------
+# Settings: token parsing
+# ---------------------------------------------------------------------------
+
+
+def test_auth_token_map_empty_when_unset() -> None:
+    s = Settings(stub_mode=True, auth_required=False)
+    assert s.auth_token_map == {}
+
+
+def test_auth_token_map_parses_bare_tokens() -> None:
+    s = Settings(stub_mode=True, auth_required=False, auth_tokens="tok-aaa,tok-bbb")
+    tm = s.auth_token_map
+    assert tm == {
+        "tok-aaa": {"client_id": "client-0", "scopes": []},
+        "tok-bbb": {"client_id": "client-1", "scopes": []},
+    }
+
+
+def test_auth_token_map_parses_named_tokens() -> None:
+    s = Settings(
+        stub_mode=True,
+        auth_required=False,
+        auth_tokens="claude:tok-aaa,n8n:tok-bbb",
+    )
+    tm = s.auth_token_map
+    assert tm["tok-aaa"]["client_id"] == "claude"
+    assert tm["tok-bbb"]["client_id"] == "n8n"
+
+
+def test_auth_token_map_tolerates_whitespace_and_blank_entries() -> None:
+    s = Settings(
+        stub_mode=True,
+        auth_required=False,
+        auth_tokens="  claude : tok-aaa , , n8n:tok-bbb  ",
+    )
+    tm = s.auth_token_map
+    assert {meta["client_id"] for meta in tm.values()} == {"claude", "n8n"}
+
+
+def test_auth_token_map_rejects_duplicate_tokens() -> None:
+    s = Settings(
+        stub_mode=True,
+        auth_required=False,
+        auth_tokens="claude:dup,n8n:dup",
+    )
+    with pytest.raises(ValueError, match="reuses a token"):
+        _ = s.auth_token_map
+
+
+def test_auth_token_map_rejects_empty_token_value() -> None:
+    s = Settings(stub_mode=True, auth_required=False, auth_tokens="claude:")
+    with pytest.raises(ValueError, match="missing a token value"):
+        _ = s.auth_token_map
+
+
+# ---------------------------------------------------------------------------
+# build_server: secure-by-default gate
+# ---------------------------------------------------------------------------
+
+
+def test_http_transport_refuses_to_start_without_tokens(stub_state: StubState) -> None:
+    s = Settings(
+        stub_mode=True,
+        log_format="text",
+        mcp_transport="streamable-http",
+        auth_required=True,
+        auth_tokens="",
+    )
+    with pytest.raises(ValueError, match="MCP_UNIFI_AUTH_TOKENS"):
+        build_server(s, stub=stub_state)
+
+
+def test_http_transport_opt_out_warns_but_boots(
+    stub_state: StubState, caplog: pytest.LogCaptureFixture
+) -> None:
+    s = Settings(
+        stub_mode=True,
+        log_format="text",
+        mcp_transport="streamable-http",
+        auth_required=False,
+        auth_tokens="",
+    )
+    with caplog.at_level(logging.WARNING, logger="mcp_unifi.server"):
+        server = build_server(s, stub=stub_state)
+    assert isinstance(server, FastMCP)
+    assert any("WITHOUT authentication" in rec.message for rec in caplog.records)
+
+
+def test_http_transport_with_tokens_wires_static_verifier(stub_state: StubState) -> None:
+    s = Settings(
+        stub_mode=True,
+        log_format="text",
+        mcp_transport="streamable-http",
+        auth_required=True,
+        auth_tokens="claude:tok-aaa",
+    )
+    provider = _build_auth_provider(s)
+    assert isinstance(provider, StaticTokenVerifier)
+    assert "tok-aaa" in provider.tokens
+    assert provider.tokens["tok-aaa"]["client_id"] == "claude"
+
+
+def test_stdio_transport_skips_auth_even_without_tokens(stub_state: StubState) -> None:
+    s = Settings(
+        stub_mode=True,
+        log_format="text",
+        mcp_transport="stdio",
+        auth_required=True,  # ignored on stdio
+        auth_tokens="",
+    )
+    assert _build_auth_provider(s) is None
+    server = build_server(s, stub=stub_state)
+    assert isinstance(server, FastMCP)
+
+
+# ---------------------------------------------------------------------------
+# Audit log carries client_id (or None when no auth context)
+# ---------------------------------------------------------------------------
+
+
+def _text(result: Any) -> str:
+    return result.content[0].text
+
+
+async def _call(server: FastMCP, name: str, args: dict[str, Any] | None = None) -> Any:
+    raw = await server.call_tool(name, args or {})
+    return json.loads(_text(raw))
+
+
+async def test_audit_records_none_client_id_outside_auth_context(
+    stub_state: StubState, tmp_path: Path
+) -> None:
+    """Direct ``call_tool`` bypasses HTTP/auth; client_id should be None.
+
+    This also confirms the field is present in the envelope (default None on
+    the dataclass), so older replay tools that don't know about ``client_id``
+    keep parsing the JSON cleanly.
+    """
+    log_path = tmp_path / "audit.jsonl"
+    sink = FileSink(log_path)
+    set_audit_log(AuditLog(sink=sink))
+
+    s = Settings(
+        stub_mode=True,
+        log_format="text",
+        mcp_transport="stdio",
+        auth_required=False,
+    )
+    server = build_server(s, stub=stub_state)
+
+    await _call(server, "list_networks")
+
+    events = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+    assert len(events) == 1
+    assert "client_id" in events[0]
+    assert events[0]["client_id"] is None

--- a/tests/test_tool_descriptions.py
+++ b/tests/test_tool_descriptions.py
@@ -106,7 +106,7 @@ def all_tools() -> list[dict[str, Any]]:
     prior = os.environ.get("MCP_UNIFI_MODULES_ENABLED")
     os.environ["MCP_UNIFI_MODULES_ENABLED"] = "network,protect"
     try:
-        settings = Settings(stub_mode=True, log_format="text")
+        settings = Settings(stub_mode=True, log_format="text", mcp_transport="stdio")
         server = build_server(settings)
     finally:
         if prior is None:


### PR DESCRIPTION
## Summary

- Adds bearer-token authentication to the streamable-HTTP transport via FastMCP's `StaticTokenVerifier`. Stdio transport is unaffected — parent process owns the security boundary there.
- **Secure by default**: `build_server` refuses to start over HTTP without `MCP_UNIFI_AUTH_TOKENS` configured. Opt-out is `MCP_UNIFI_AUTH_REQUIRED=false` (logs a loud WARNING).
- Audit log gains a `client_id` field so each tool call traces back to a named caller (`claude`, `n8n`, etc.). Schema stays at `"1"` — older replay tooling keeps parsing because the new field defaults to `null`.

## Why now

The server exposes 57 Network + 11 Protect tools, many destructive (delete VLAN, rewrite firewall, disable IDS/IPS, block client, dump backup). Before this PR, anyone reaching `http://<host>:3714/mcp` had admin-equivalent access. On a tailnet or multi-device LAN, that's a single-compromised-IoT-device away from a problem. v0.9.0 closes that.

## Breaking change

HTTP-transport users running v0.8.0 must do one of these before upgrading:

```bash
# Option A — generate a token (recommended)
openssl rand -hex 32
MCP_UNIFI_AUTH_TOKENS=claude:<token>

# Option B — opt out (single-host trusted boundary only)
MCP_UNIFI_AUTH_REQUIRED=false
```

Stdio users (Claude Desktop, `uvx mcp-unifi`, `.dxt` bundle) are unaffected.

## What's in the PR

- **Core**: `Settings.auth_tokens` + `auth_required` + `auth_token_map` parser; new `_build_auth_provider` in `server.py`.
- **Audit**: `client_id` field on `AuditEvent`; `@audited` pulls it from `fastmcp.server.dependencies.get_access_token()` per call.
- **Helm**: chart wires `auth.tokens` (Secret) and `auth.required` (env). Backward-compatible with `existingSecret`.
- **Docs**: new `guides/auth.md` with Claude Code config example; `SECURITY.md` and `guides/security.md` updated.
- **Tests**: 11 new in `tests/test_auth.py`. 537/537 pass, 89% coverage.

## Out of scope (intentional)

- Per-tool scopes / RBAC — v1.x decision
- Token rotation API (rotate via env-var + restart)
- OAuth flows (front with an authenticating reverse proxy if needed)
- Rate limiting

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/mcp_unifi` — strict, clean
- [x] `pytest` — 537 passed, 89% coverage
- [x] `python scripts/generate_tool_manifest.py --check` — manifest in sync
- [ ] CI green on PR (lockfile drift, lint+type, tests+cov, Docker build, Trivy)
- [ ] Smoke on nix1 with `Authorization: Bearer <token>` succeeds and without → 401
