### PR TITLE
v0.9.1: env vars now read MCP_UNIFI_AUTH_TOKENS as documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-05-27
+
+### Fixed
+
+- **Auth env vars now work as documented.** v0.9.0 documented
+  ``MCP_UNIFI_AUTH_TOKENS`` and ``MCP_UNIFI_AUTH_REQUIRED`` everywhere
+  (README, guide, .env.example, Helm chart, error messages) but the
+  underlying pydantic-settings fields had no prefix alias, so only the
+  bare ``AUTH_TOKENS`` / ``AUTH_REQUIRED`` names worked. Added
+  ``validation_alias`` to both fields. Both naming schemes now resolve
+  to the same field; new deployments should use the documented
+  ``MCP_UNIFI_AUTH_TOKENS``.
+
 ## [0.9.0] - 2026-05-27
 
 > **Bearer-token authentication on HTTP transport, secure by default.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.9.0"
+version = "0.9.1"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_unifi/config.py
+++ b/src/mcp_unifi/config.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
+from pydantic import AliasChoices, BaseModel, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
+        populate_by_name=True,
     )
 
     # ------------------------------------------------------------------
@@ -134,18 +135,22 @@ class Settings(BaseSettings):
     # ------------------------------------------------------------------
     auth_tokens: str = Field(
         default="",
+        validation_alias=AliasChoices("MCP_UNIFI_AUTH_TOKENS", "auth_tokens"),
         description=(
             "Bearer tokens for HTTP transport. Comma-separated. Each entry "
             "is either a bare token (assigned synthetic client_id 'client-N') "
-            "or a 'client_id:token' pair for named clients. Ignored on stdio."
+            "or a 'client_id:token' pair for named clients. Ignored on stdio. "
+            "Env var: MCP_UNIFI_AUTH_TOKENS."
         ),
     )
     auth_required: bool = Field(
         default=True,
+        validation_alias=AliasChoices("MCP_UNIFI_AUTH_REQUIRED", "auth_required"),
         description=(
             "If True (default), HTTP transport refuses to start without "
             "auth_tokens. Set False to opt out (NOT RECOMMENDED for any "
-            "deployment beyond a single-host trusted boundary). Ignored on stdio."
+            "deployment beyond a single-host trusted boundary). Ignored on stdio. "
+            "Env var: MCP_UNIFI_AUTH_REQUIRED."
         ),
     )
 


### PR DESCRIPTION
## Summary

v0.9.0 documented `MCP_UNIFI_AUTH_TOKENS` / `MCP_UNIFI_AUTH_REQUIRED` everywhere (README, auth guide, `.env.example`, Helm chart, the error message itself) — but the pydantic-settings fields had no env alias, so only the bare `AUTH_TOKENS` / `AUTH_REQUIRED` names actually bound. Operators following the docs hit a startup `ValueError` with the env var set.

This adds `validation_alias` on both fields plus `populate_by_name=True` so:

- The documented `MCP_UNIFI_AUTH_TOKENS` / `MCP_UNIFI_AUTH_REQUIRED` env vars now work
- The bare names still work (backward-compat for anyone who already wrote v0.9.0 workarounds)
- Tests can still construct `Settings(auth_required=False)` by attribute name

## Test plan

- [x] ruff + mypy strict + 537 tests pass
- [x] Verified on nix1: setting `MCP_UNIFI_AUTH_TOKENS=claude:<token>` in .env loads correctly and the auth gate works (401 without bearer, request passes through with bearer)
- [ ] CI green
