### PR TITLE
fix: route controller-resolution errors through the err() envelope

### DIFF
--- a/src/mcp_unifi/dispatcher.py
+++ b/src/mcp_unifi/dispatcher.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal, overload
 
 from mcp_unifi.backends import (
     AccessBackend,
@@ -33,7 +34,7 @@ from mcp_unifi.clients.access_stubs import make_access_stub_state
 from mcp_unifi.clients.protect import ProtectClient
 from mcp_unifi.clients.protect_stubs import make_protect_stub_state
 from mcp_unifi.clients.stubs import make_stub_state
-from mcp_unifi.clients.unifi import UniFiClient
+from mcp_unifi.clients.unifi import UniFiClient, UniFiError
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -278,6 +279,59 @@ def build_registry(
     )
 
 
+@overload
+def resolve_backend(
+    registry: ControllerRegistry, controller: str, kind: Literal["network"] = ...
+) -> Backend: ...
+@overload
+def resolve_backend(
+    registry: ControllerRegistry, controller: str, kind: Literal["protect"]
+) -> ProtectBackend: ...
+@overload
+def resolve_backend(
+    registry: ControllerRegistry, controller: str, kind: Literal["access"]
+) -> AccessBackend: ...
+def resolve_backend(
+    registry: ControllerRegistry,
+    controller: str,
+    kind: Literal["network", "protect", "access"] = "network",
+) -> Backend | ProtectBackend | AccessBackend:
+    """Resolve a controller backend for a tool, mapping resolution failures to UniFiError.
+
+    Every tool body wraps its work in ``except UniFiError`` and returns a
+    formatted ``err(...)`` envelope. The registry getters, however, raise
+    dispatcher-layer errors that are *siblings* of :class:`UniFiError` (all
+    subclass :class:`RuntimeError`, none subclass the others), so they would
+    otherwise escape the tool's handler and surface as a raw framework error:
+
+    * :class:`AccessNotAvailableError` / :class:`ProtectNotAvailableError` when
+      the module is enabled but the registry holds no backend for it (e.g. the
+      ``access`` module is on but no controller has ``access_*`` config in real
+      mode).
+    * :class:`UnknownControllerError` when ``controller`` names a controller the
+      registry doesn't know (a typo'd or stale ``controller`` argument).
+
+    Translating them to :class:`UniFiError` here lets every current and future
+    tool handle a missing module or unknown controller through the
+    ``except UniFiError`` path it already has, with no per-tool change. Callers
+    that want the typed errors (tests, non-tool code) keep using the registry
+    getters directly.
+    """
+    getters: dict[str, Callable[[str], Backend | ProtectBackend | AccessBackend]] = {
+        "network": registry.get,
+        "protect": registry.get_protect,
+        "access": registry.get_access,
+    }
+    try:
+        return getters[kind](controller)
+    except (
+        ProtectNotAvailableError,
+        AccessNotAvailableError,
+        UnknownControllerError,
+    ) as exc:
+        raise UniFiError(str(exc)) from exc
+
+
 def _enabled_modules() -> tuple[str, ...]:
     raw = os.environ.get("MCP_UNIFI_MODULES_ENABLED", "").strip()
     if not raw:
@@ -323,4 +377,5 @@ __all__ = [
     "UnknownModuleError",
     "build_registry",
     "register_modules",
+    "resolve_backend",
 ]

--- a/src/mcp_unifi/modules/access/__init__.py
+++ b/src/mcp_unifi/modules/access/__init__.py
@@ -22,6 +22,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -75,7 +76,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_doors())
         except UniFiError as exc:
             logger.exception("list_doors failed")
@@ -99,7 +100,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             door = await backend.get_door(door_id)
             if door is None:
                 return err(f"door {door_id} not found")
@@ -124,7 +125,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_door_groups())
         except UniFiError as exc:
             logger.exception("list_door_groups failed")
@@ -152,7 +153,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_access_policies())
         except UniFiError as exc:
             logger.exception("list_access_policies failed")
@@ -176,7 +177,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             policy = await backend.get_access_policy(policy_id)
             if policy is None:
                 return err(f"access policy {policy_id} not found")
@@ -207,7 +208,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_credentials())
         except UniFiError as exc:
             logger.exception("list_credentials failed")
@@ -231,7 +232,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             cred = await backend.get_credential(credential_id)
             if cred is None:
                 return err(f"credential {credential_id} not found")
@@ -270,7 +271,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if credential_type and credential_type not in CREDENTIAL_TYPES:
             return err(f"credential_type {credential_type!r} not in {sorted(CREDENTIAL_TYPES)}")
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             credentials = await backend.list_credentials()
         except UniFiError as exc:
             logger.exception("audit_expiring_credentials failed")
@@ -321,7 +322,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_visitors())
         except UniFiError as exc:
             logger.exception("list_visitors failed")
@@ -344,7 +345,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             visitor = await backend.get_visitor(visitor_id)
             if visitor is None:
                 return err(f"visitor {visitor_id} not found")
@@ -388,7 +389,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if result and result not in EVENT_RESULTS:
             return err(f"result {result!r} not in {sorted(EVENT_RESULTS)}")
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             start_ms, end_ms = _hours_window(hours_back)
             events = await backend.list_events(
                 start_ms, end_ms, limit, result=result, door_id=door_id
@@ -418,7 +419,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             start_ms, end_ms = _hours_window(24)
             events = await backend.list_events(start_ms, end_ms, limit)
             return format_json(events)
@@ -449,7 +450,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             start_ms, end_ms = _hours_window(hours_back)
             events = await backend.list_events(start_ms, end_ms, 500)
         except UniFiError as exc:
@@ -517,7 +518,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             start_ms, end_ms = _hours_window(hours_back)
             events = await backend.list_events(
                 start_ms, end_ms, limit, result="denied", door_id=door_id
@@ -549,7 +550,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_devices())
         except UniFiError as exc:
             logger.exception("list_access_devices failed")
@@ -573,7 +574,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             device = await backend.get_device(device_id)
             if device is None:
                 return err(f"access device {device_id} not found")
@@ -604,7 +605,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.get_system_info())
         except UniFiError as exc:
             logger.exception("get_access_system_info failed")
@@ -627,7 +628,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             controller: Name of the UniFi controller to target.
         """
         try:
-            backend = registry.get_access(controller)
+            backend = resolve_backend(registry, controller, "access")
             return format_json(await backend.list_users())
         except UniFiError as exc:
             logger.exception("list_access_users failed")

--- a/src/mcp_unifi/modules/network/backup.py
+++ b/src/mcp_unifi/modules/network/backup.py
@@ -82,6 +82,7 @@ from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.backends import Backend
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -380,9 +381,9 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
-        except KeyError as exc:
-            return err(str(exc).strip("'"))
+            backend = resolve_backend(registry, controller)
+        except UniFiError as exc:
+            return err(str(exc))
 
         try:
             resources = await _snapshot(backend)
@@ -511,9 +512,9 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
 
         try:
-            backend = registry.get(controller)
-        except KeyError as exc:
-            return err(str(exc).strip("'"))
+            backend = resolve_backend(registry, controller)
+        except UniFiError as exc:
+            return err(str(exc))
 
         # Snapshot the live controller (with _id preserved for delete dispatch).
         try:

--- a/src/mcp_unifi/modules/network/clients.py
+++ b/src/mcp_unifi/modules/network/clients.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -42,7 +43,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_clients())
         except UniFiError as exc:
             logger.exception("list_clients failed")
@@ -83,7 +84,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             blocked = await backend.block_client(mac)
             if blocked is None:
                 return err(f"client {mac} not found")
@@ -126,7 +127,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             unblocked = await backend.unblock_client(mac)
             if unblocked is None:
                 return err(f"client {mac} not found")
@@ -171,7 +172,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             ok = await backend.reconnect_client(mac)
             return format_json({"reconnected": ok, "mac": mac})
         except UniFiError as exc:

--- a/src/mcp_unifi/modules/network/composites.py
+++ b/src/mcp_unifi/modules/network/composites.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.backends import Backend
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import (
     format_json,
@@ -186,7 +187,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
 
-        backend = registry.get(controller)
+        backend = resolve_backend(registry, controller)
         created: dict[str, Any] = {
             "network": None,
             "wlan": None,
@@ -373,7 +374,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
 
-        backend = registry.get(controller)
+        backend = resolve_backend(registry, controller)
         created: dict[str, Any] = {
             "lease": None,
             "firewall_rule": None,
@@ -488,7 +489,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             blocked = await backend.block_client(mac)
             if blocked is None:
                 return err(f"client {mac} not found")
@@ -622,7 +623,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
 
-        backend = registry.get(controller)
+        backend = resolve_backend(registry, controller)
         created: dict[str, Any] = {
             "network": None,
             "wlan": None,
@@ -723,7 +724,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             fw_rules = await backend.list_firewall_rules()
             port_forwards = await backend.list_port_forwards()
 

--- a/src/mcp_unifi/modules/network/devices.py
+++ b/src/mcp_unifi/modules/network/devices.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -39,7 +40,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_devices())
         except UniFiError as exc:
             logger.exception("list_devices failed")
@@ -82,7 +83,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             ok = await backend.restart_device(mac)
             if not ok:
                 return err(f"device {mac} not found")
@@ -129,7 +130,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             ok = await backend.locate_device(mac, on)
             if not ok:
                 return err(f"device {mac} not found")
@@ -198,7 +199,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             updated = await backend.set_port_state(
                 device_mac,
                 port_idx,

--- a/src/mcp_unifi/modules/network/dhcp.py
+++ b/src/mcp_unifi/modules/network/dhcp.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
@@ -40,7 +41,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_dhcp_leases())
         except UniFiError as exc:
             logger.exception("list_dhcp_leases failed")
@@ -101,7 +102,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.create_dhcp_lease(payload))
         except UniFiError as exc:
             logger.exception("create_static_dhcp_lease failed", extra={"mac": mac})
@@ -171,7 +172,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             user = await backend.find_user_by_mac(mac)
             if not user or not user.get("_id"):
                 return err(
@@ -226,7 +227,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             leases = await backend.list_dhcp_leases()
         except UniFiError as exc:
             logger.exception(

--- a/src/mcp_unifi/modules/network/drift.py
+++ b/src/mcp_unifi/modules/network/drift.py
@@ -57,6 +57,7 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -463,9 +464,9 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
 
         try:
-            backend = registry.get(controller)
-        except KeyError as exc:
-            return err(str(exc).strip("'"))
+            backend = resolve_backend(registry, controller)
+        except UniFiError as exc:
+            return err(str(exc))
 
         drifts: list[dict[str, Any]] = []
         # Always pull networks because WLANs reference them.

--- a/src/mcp_unifi/modules/network/firewall.py
+++ b/src/mcp_unifi/modules/network/firewall.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
@@ -40,7 +41,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_firewall_rules())
         except UniFiError as exc:
             logger.exception("list_firewall_rules failed")
@@ -153,7 +154,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.create_firewall_rule(payload))
         except UniFiError as exc:
             logger.exception("create_firewall_rule failed", extra={"rule_name": name})
@@ -200,7 +201,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             updated = await backend.update_firewall_rule(rule_id, updates)
             if updated is None:
                 return err(f"firewall rule {rule_id} not found")
@@ -249,7 +250,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             rules = await backend.list_firewall_rules()
         except UniFiError as exc:
             logger.exception(

--- a/src/mcp_unifi/modules/network/honeypot.py
+++ b/src/mcp_unifi/modules/network/honeypot.py
@@ -24,6 +24,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
@@ -105,7 +106,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             record = await backend.get_setting("ips")
             networks = await _network_lookup(backend)
         except UniFiError as exc:
@@ -156,7 +157,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(validation_err)
 
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             networks = await _network_lookup(backend)
         except UniFiError as exc:
             logger.exception("create_honeypot lookup failed")
@@ -245,7 +246,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
 
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             record = await backend.get_setting("ips")
         except UniFiError as exc:
             logger.exception("delete_honeypot lookup failed")

--- a/src/mcp_unifi/modules/network/observability.py
+++ b/src/mcp_unifi/modules/network/observability.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -38,7 +39,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.get_site_health())
         except UniFiError as exc:
             logger.exception("get_site_health failed")
@@ -62,7 +63,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.get_wan_status())
         except UniFiError as exc:
             logger.exception("get_wan_status failed")
@@ -87,7 +88,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if not 1 <= limit <= 1000:
             return err("limit must be between 1 and 1000")
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_events(limit))
         except UniFiError as exc:
             logger.exception("list_events failed")
@@ -118,7 +119,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if not 1 <= limit <= 1000:
             return err("limit must be between 1 and 1000")
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_alarms(limit, archived))
         except UniFiError as exc:
             logger.exception("list_alarms failed")
@@ -141,7 +142,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.trigger_speedtest())
         except UniFiError as exc:
             logger.exception("trigger_speedtest failed")
@@ -167,7 +168,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if not 1 <= limit <= 1000:
             return err("limit must be between 1 and 1000")
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.get_speedtest_results(limit))
         except UniFiError as exc:
             logger.exception("get_speedtest_results failed")
@@ -194,7 +195,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if not 1 <= limit <= 1000:
             return err("limit must be between 1 and 1000")
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.top_talkers(limit))
         except UniFiError as exc:
             logger.exception("list_top_talkers failed")

--- a/src/mcp_unifi/modules/network/port_forwards.py
+++ b/src/mcp_unifi/modules/network/port_forwards.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
@@ -39,7 +40,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_port_forwards())
         except UniFiError as exc:
             logger.exception("list_port_forwards failed")
@@ -106,7 +107,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.create_port_forward(payload))
         except UniFiError as exc:
             logger.exception("create_port_forward failed", extra={"forward_name": name})
@@ -152,7 +153,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             updated = await backend.update_port_forward(forward_id, updates)
             if updated is None:
                 return err(f"port forward {forward_id} not found")
@@ -201,7 +202,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             forwards = await backend.list_port_forwards()
         except UniFiError as exc:
             logger.exception(

--- a/src/mcp_unifi/modules/network/port_profiles.py
+++ b/src/mcp_unifi/modules/network/port_profiles.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
@@ -41,7 +42,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_port_profiles())
         except UniFiError as exc:
             logger.exception("list_port_profiles failed")
@@ -103,7 +104,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.create_port_profile(payload))
         except UniFiError as exc:
             logger.exception("create_port_profile failed", extra={"profile_name": name})
@@ -152,7 +153,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             updated = await backend.update_port_profile(profile_id, updates)
             if updated is None:
                 return err(f"port profile {profile_id} not found")
@@ -201,7 +202,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             profiles = await backend.list_port_profiles()
         except UniFiError as exc:
             logger.exception(

--- a/src/mcp_unifi/modules/network/teleport.py
+++ b/src/mcp_unifi/modules/network/teleport.py
@@ -36,6 +36,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -95,7 +96,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             record = await backend.get_setting("teleport")
             networks_raw = await backend.list_networks()
         except UniFiError as exc:
@@ -155,7 +156,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
 
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             record = await backend.set_setting("teleport", patch)
         except UniFiError as exc:
             logger.exception("set_teleport_enabled failed")

--- a/src/mcp_unifi/modules/network/threat_management.py
+++ b/src/mcp_unifi/modules/network/threat_management.py
@@ -25,6 +25,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -88,7 +89,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             record = await backend.get_setting("ips")
         except UniFiError as exc:
             logger.exception("get_threat_management failed")
@@ -166,7 +167,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
 
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             record = await backend.set_setting("ips", patch)
         except UniFiError as exc:
             logger.exception("set_threat_management failed")

--- a/src/mcp_unifi/modules/network/vlans.py
+++ b/src/mcp_unifi/modules/network/vlans.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import (
     format_json,
@@ -45,7 +46,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_networks())
         except UniFiError as exc:
             logger.exception("list_networks failed")
@@ -127,7 +128,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.create_network(payload))
         except UniFiError as exc:
             logger.exception("create_vlan failed", extra={"vlan_name": name})
@@ -174,7 +175,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             updated = await backend.update_network(network_id, updates)
             if updated is None:
                 return err(f"network {network_id} not found")
@@ -225,7 +226,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             networks = await backend.list_networks()
         except UniFiError as exc:
             logger.exception("delete_vlan preview lookup failed", extra={"network_id": network_id})

--- a/src/mcp_unifi/modules/network/wlans.py
+++ b/src/mcp_unifi/modules/network/wlans.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import (
     format_json,
@@ -44,7 +45,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_wlans())
         except UniFiError as exc:
             logger.exception("list_wlans failed")
@@ -72,7 +73,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             return format_json(await backend.list_ap_groups())
         except UniFiError as exc:
             logger.exception("list_ap_groups failed")
@@ -135,7 +136,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 predicted change set.
         """
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
         except UniFiError as exc:
             logger.exception("create_wlan failed", extra={"wlan_name": name})
             return err(str(exc))
@@ -221,7 +222,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             updated = await backend.update_wlan(wlan_id, updates)
             if updated is None:
                 return err(f"wlan {wlan_id} not found")
@@ -271,7 +272,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get(controller)
+            backend = resolve_backend(registry, controller)
             wlans = await backend.list_wlans()
         except UniFiError as exc:
             logger.exception("delete_wlan preview lookup failed", extra={"wlan_id": wlan_id})

--- a/src/mcp_unifi/modules/protect/__init__.py
+++ b/src/mcp_unifi/modules/protect/__init__.py
@@ -24,6 +24,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
 from mcp_unifi.modules.network._common import format_json, make_err
 
@@ -78,7 +79,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             return format_json(await backend.list_cameras())
         except UniFiError as exc:
             logger.exception("list_cameras failed")
@@ -103,7 +104,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             cam = await backend.get_camera(camera_id)
             if cam is None:
                 return err(f"camera {camera_id} not found")
@@ -139,7 +140,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             start_ms, end_ms = _hours_window(hours_back)
             events = await backend.list_events(["motion"], start_ms, end_ms, limit)
             events = _filter_by_camera(events, camera_id)
@@ -181,7 +182,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         if detection_type not in SMART_DETECT_TYPES:
             return err(f"detection_type {detection_type!r} not in {sorted(SMART_DETECT_TYPES)}")
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             start_ms, end_ms = _hours_window(hours_back)
             raw = await backend.list_events(["smartDetectZone"], start_ms, end_ms, limit)
             filtered = [evt for evt in raw if detection_type in (evt.get("smartDetectTypes") or [])]
@@ -211,7 +212,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             data = await backend.get_snapshot(camera_id)
             encoded = base64.b64encode(data).decode()
             return format_json(
@@ -246,7 +247,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             data = await backend.get_event_thumbnail(event_id)
             encoded = base64.b64encode(data).decode()
             return format_json(
@@ -285,7 +286,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             start_ms, end_ms = _hours_window(hours_back)
             return format_json(await backend.list_recordings(camera_id, start_ms, end_ms))
         except UniFiError as exc:
@@ -331,7 +332,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             updated = await backend.update_camera(camera_id, patch)
             if updated is None:
                 return err(f"camera {camera_id} not found")
@@ -381,7 +382,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             updated = await backend.update_camera(camera_id, patch)
             if updated is None:
                 return err(f"camera {camera_id} not found")
@@ -432,7 +433,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             updated = await backend.update_camera(camera_id, patch)
             if updated is None:
                 return err(f"camera {camera_id} not found")
@@ -460,7 +461,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 ``"default"``.
         """
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             cameras = await backend.list_cameras()
             doorbells = [
                 {
@@ -560,7 +561,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
 
         try:
-            backend = registry.get_protect(controller)
+            backend = resolve_backend(registry, controller, "protect")
             original = await backend.get_camera(camera_id)
             if original is None:
                 return err(f"camera {camera_id} not found")

--- a/tests/network/test_multi_site.py
+++ b/tests/network/test_multi_site.py
@@ -71,17 +71,20 @@ async def test_create_vlan_does_not_leak_across_controllers(
     assert len(office_nets) == 1
 
 
-async def test_unknown_controller_raises_clear_error(
+async def test_unknown_controller_returns_clear_error(
     multi_site_server: FastMCP,
 ) -> None:
     """Calling a tool with an unconfigured controller name surfaces a clear error.
 
     Behavior must NOT silently fall back to ``"default"`` — that would let a
-    typo silently target the wrong site.
+    typo silently target the wrong site. As of the ``resolve_backend()`` helper,
+    the dispatcher's ``UnknownControllerError`` is normalised to a ``UniFiError``
+    and returned through the tool's standard ``err()`` envelope rather than
+    raised, so the caller sees a structured error instead of a transport-level
+    exception.
     """
-    with pytest.raises(Exception) as excinfo:
-        await _call(multi_site_server, "list_devices", {"controller": "ghost"})
-    msg = str(excinfo.value)
+    result = await _call(multi_site_server, "list_devices", {"controller": "ghost"})
+    msg = result["error"]
     assert "ghost" in msg
     assert "home" in msg and "office" in msg  # available controllers listed
 

--- a/tests/test_resolve_backend.py
+++ b/tests/test_resolve_backend.py
@@ -1,0 +1,91 @@
+"""Tests for :func:`resolve_backend`, the tool-facing backend resolver.
+
+Tool bodies catch :class:`UniFiError` and return a formatted ``err(...)``
+envelope. The registry getters, however, raise dispatcher-layer errors that
+are *siblings* of ``UniFiError`` (``AccessNotAvailableError``,
+``ProtectNotAvailableError``, ``UnknownControllerError``), so a tool that
+called a getter directly would let those escape its handler and surface as a
+raw framework error. ``resolve_backend`` translates them to ``UniFiError`` so
+every tool's existing ``except UniFiError`` path covers them.
+
+These tests pin both halves: the unit translation, and the end-to-end result
+that an access tool now returns an error envelope (not a raised exception)
+when the module is enabled but no Access backend was wired.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+
+from mcp_unifi.backends import AccessStubBackend, StubBackend
+from mcp_unifi.clients.access_stubs import make_access_stub_state
+from mcp_unifi.clients.stubs import make_stub_state
+from mcp_unifi.clients.unifi import UniFiError
+from mcp_unifi.config import Settings
+from mcp_unifi.dispatcher import ControllerRegistry, resolve_backend
+from mcp_unifi.server import build_server
+
+
+def test_missing_access_backend_becomes_unifierror() -> None:
+    """Access module enabled but no Access backend → UniFiError, not AccessNotAvailableError."""
+    registry = ControllerRegistry({"default": StubBackend(make_stub_state())})
+    with pytest.raises(UniFiError) as excinfo:
+        resolve_backend(registry, "default", "access")
+    # The clean operator-facing message is preserved.
+    assert "Access" in str(excinfo.value)
+
+
+def test_unknown_controller_becomes_unifierror() -> None:
+    """A bad controller name surfaces as UniFiError so the tool handler catches it."""
+    registry = ControllerRegistry(
+        {"default": StubBackend(make_stub_state())},
+        access_backends={"default": AccessStubBackend(make_access_stub_state())},
+    )
+    with pytest.raises(UniFiError):
+        resolve_backend(registry, "typo", "access")
+    with pytest.raises(UniFiError):
+        resolve_backend(registry, "typo")  # network kind (default)
+
+
+def test_happy_path_returns_backend() -> None:
+    """A configured controller resolves to its backend unchanged."""
+    network = StubBackend(make_stub_state())
+    access = AccessStubBackend(make_access_stub_state())
+    registry = ControllerRegistry({"default": network}, access_backends={"default": access})
+    assert resolve_backend(registry, "default") is network
+    assert resolve_backend(registry, "default", "access") is access
+
+
+async def test_access_tool_returns_err_envelope_without_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: an access tool with no Access backend returns err(), never raises.
+
+    Reproduces the v0.10 gap: the ``access`` module is enabled (so its tools are
+    registered) but real mode has no ``access_*`` config, so the registry holds
+    no Access backend. Before the fix, the resulting AccessNotAvailableError
+    escaped the tool's ``except UniFiError`` and surfaced as a framework error.
+    """
+    for var in ("MCP_UNIFI_CONTROLLERS_FILE", "UNIFI_HOST", "UNIFI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("MCP_UNIFI_MODULES_ENABLED", "access")
+    # Stub mode keeps the test offline, but we inject no access stub, so the
+    # registry has Network + Access stub backends only if build wires them.
+    # Force the missing-backend path by building real-mode settings with a
+    # network controller but no access_* fields.
+    settings = Settings(
+        stub_mode=False,
+        log_format="text",
+        auth_required=False,
+        controllers=[{"name": "default", "host": "example", "api_key": "k", "port": 443}],
+    )
+    server: FastMCP = build_server(settings)
+
+    raw = await server.call_tool("list_doors", {})
+    payload: dict[str, Any] = json.loads(raw.content[0].text)
+    assert "error" in payload
+    assert "Access" in payload["error"]


### PR DESCRIPTION
## Problem

Tool bodies catch `UniFiError` and return a formatted `err()` envelope. But the registry getters raise dispatcher-layer errors that are **siblings** of `UniFiError` (`AccessNotAvailableError`, `ProtectNotAvailableError`, `UnknownControllerError` — all subclass `RuntimeError`, none subclass the others), so they slipped past every tool's `except UniFiError` and surfaced as raw framework errors instead of the documented envelope.

Most reachable on the new v0.10 **Access module**: `register_modules` registers a module's tools whenever it's in `MCP_UNIFI_MODULES_ENABLED`, with no backend check, and in real mode an Access backend is only created when `access_host`/`access_api_key` are set. So enabling `access` without those creds (explicitly anticipated — see the comment in `build_registry`) registered the tools but left the registry with no Access backend → the first tool call raised an unhandled `AccessNotAvailableError`.

Found during an Opus 4.8 code review of the v0.10 diff.

## Fix

New `dispatcher.resolve_backend(registry, controller, kind)` translates all three resolution errors to `UniFiError` at the single seam every tool already guards with `except UniFiError`. `@overload`s keep the return type precise per `kind` for mypy.

- Migrated all access (18), new network honeypot/teleport/threat (7), existing network (48), and protect (12) call sites.
- `backup.py` and `drift.py` previously caught the resolution `KeyError` directly — converted those handlers to `except UniFiError` to match.

## Behavior change

An unknown/typo'd `controller` name on a network or protect tool now returns the `err()` envelope instead of raising a transport-level exception. The **no-silent-fallback-to-default** guarantee is unchanged. `tests/network/test_multi_site.py` updated to pin the new contract.

## Tests

- New `tests/test_resolve_backend.py`: unit translation for missing-backend and unknown-controller, happy path, and an end-to-end test reproducing the exact Access gap (module enabled, no backend → `err()` envelope, no raise).
- Full suite: **623 passed**; ruff + mypy clean across 41 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)