### PR TITLE
Merge v0.12.0 (released 2026-06-03) back into main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.11.0"
+version = "0.12.0"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_unifi/__init__.py
+++ b/src/mcp_unifi/__init__.py
@@ -17,4 +17,4 @@ a real UCG-Fiber, UDM Pro, or other UniFi OS gateway.
 
 from __future__ import annotations
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/src/mcp_unifi/clients/unifi.py
+++ b/src/mcp_unifi/clients/unifi.py
@@ -110,6 +110,34 @@ class UniFiClient:
     async def _get(self, path: str) -> Any:
         return await self._request("GET", f"{self._site_path}{path}")
 
+    async def _get_optional(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> Any:
+        """GET that tolerates a route the firmware does not expose.
+
+        Some legacy endpoints (notably ``/stat/event``) are absent on newer
+        UniFi Network firmware and answer 404 (``api.err.NotFound``) or 400
+        (``api.err.InvalidObject``). For read-only observability calls that have
+        no working alternative on this gateway, we treat those as "no records"
+        rather than surfacing an error, while still raising on genuine transport
+        or auth failures.
+        """
+        query = ""
+        if params:
+            query = "?" + "&".join(f"{k}={v}" for k, v in params.items())
+        try:
+            return await self._request("GET", f"{self._site_path}{path}{query}")
+        except UniFiError as exc:
+            text = str(exc)
+            if " returned 404" in text or " returned 400" in text:
+                logger.info(
+                    "UniFi endpoint not available on this firmware; "
+                    "returning empty result",
+                    extra={"path": path, "error": text[:200]},
+                )
+                return []
+            raise
+
     async def _post(self, path: str, payload: dict[str, Any]) -> Any:
         return await self._request("POST", f"{self._site_path}{path}", json=payload)
 
@@ -363,36 +391,46 @@ class UniFiClient:
     async def list_events(self, limit: int) -> list[UniFiRecord]:
         """Return recent controller events, newest first.
 
-        UniFi OS gateways (UCG-Fiber, UDM) on UniFi Network 9.x reject the
-        legacy ``GET /stat/event?_limit=...`` form with HTTP 404
-        (``api.err.NotFound``). The modern contract is a ``POST`` to
-        ``/stat/event`` with a JSON body carrying ``_limit`` and ``_sort``
-        (same pattern as ``get_speedtest_results``). Verified against the
-        unpoller/unifi reference client, which posts
-        ``{"_limit": N, "within": H, "_sort": "-time"}`` to this path.
-        We omit ``within`` so the controller returns the most recent events
-        regardless of age, then let the caller's ``limit`` bound the set.
+        Probed live against a UCG-Fiber on UniFi Network 10.4.57 (2026-06-03):
+        the legacy event log route is **not exposed** on this firmware via the
+        local API-key surface. ``GET``/``POST /stat/event`` both return HTTP 404
+        (``api.err.NotFound``), the v2 (``/v2/api/site/default/...``) tree has no
+        event path, and the official Integration API (``/integration/v1/...``)
+        has no events resource. ``/rest/event`` answers 400
+        (``api.err.InvalidObject``) — it is a config collection, not a log
+        reader. The 404 is route-absence, not a scope gate: sibling ``stat/*``
+        routes (``stat/sta``, ``stat/rogueap``, ``stat/health``) all return 200
+        with the same key.
+
+        We attempt the legacy ``GET /stat/event`` for forward compatibility (a
+        future firmware may restore it) and, on the expected NOT_FOUND, return
+        an empty list rather than raising. Alarms (``list_alarms``) remain the
+        working observability surface on this gateway.
         """
-        payload: dict[str, Any] = {"_limit": limit, "_sort": "-time"}
-        records = await self._post("/stat/event", payload) or []
+        records = await self._get_optional(
+            "/stat/event", params={"_limit": limit, "_sort": "-time"}
+        )
         return records if isinstance(records, list) else []
 
     async def list_alarms(self, limit: int, archived: bool) -> list[UniFiRecord]:
         """Return controller alarms, active or archived, newest first.
 
-        Same modern-controller contract as ``list_events``: UniFi Network 9.x
-        404s the legacy ``GET /stat/alarm?archived=...&_limit=...`` form. We
-        ``POST`` to ``/stat/alarm`` with ``{"_limit", "_sort"}`` and filter on
-        the ``archived`` flag client-side, because the controller's server-side
-        ``archived`` body filter is inconsistent across firmware revisions.
-        Alarm records carry the originating client MAC (``user`` / ``sta``),
-        AP MAC (``ap``), ``ssid``, ``subsystem``, ``key``, ``msg``, and
-        ``time`` / ``datetime`` fields, which pass straight through to callers.
+        Probed live against a UCG-Fiber on UniFi Network 10.4.57 (2026-06-03):
+        the working route is ``GET /proxy/network/api/s/{site}/list/alarm``,
+        which returns HTTP 200 with the standard ``{"meta", "data"}`` envelope
+        and honours a server-side ``?archived=<bool>`` filter. The previously
+        shipped ``POST /stat/alarm`` form returns HTTP 404 on this firmware and
+        is abandoned.
+
+        We pass ``archived`` through as the server-side query filter and also
+        apply a defensive client-side filter, then bound the result to
+        ``limit``. Alarm records carry the originating client MAC
+        (``user`` / ``sta``), AP MAC (``ap``), ``ssid``, ``subsystem``,
+        ``key``, ``msg``, and ``time`` / ``datetime`` fields, which pass
+        straight through to callers.
         """
-        # Over-fetch so client-side archived filtering still yields up to
-        # ``limit`` matching records.
-        payload: dict[str, Any] = {"_limit": max(limit * 4, limit), "_sort": "-time"}
-        records = await self._post("/stat/alarm", payload) or []
+        archived_flag = "true" if archived else "false"
+        records = await self._get(f"/list/alarm?archived={archived_flag}") or []
         if not isinstance(records, list):
             return []
         filtered = [

--- a/tests/network/test_observability.py
+++ b/tests/network/test_observability.py
@@ -156,35 +156,38 @@ async def test_real_get_wan_status_unknown_when_missing(real_server: FastMCP) ->
 
 @respx.mock
 async def test_real_list_events(real_server: FastMCP) -> None:
-    """UniFi Network 9.x (UCG-Fiber) 404s the legacy ``GET /stat/event?_limit=``
-    form. The client now POSTs ``{"_limit", "_sort"}`` to ``/stat/event``."""
-    import json as _json
+    """On a UCG-Fiber (Network 10.4.57) the legacy event log route is absent and
+    returns 404 ``api.err.NotFound`` (probed live 2026-06-03). The client GETs
+    ``/stat/event`` and, on the firmware's 404, returns an empty list rather
+    than raising. A future firmware that restores the route and returns 200
+    flows records straight through."""
+    respx.get(f"{BASE}/stat/event").mock(
+        return_value=httpx.Response(
+            404, json={"meta": {"rc": "error", "msg": "api.err.NotFound"}, "data": []}
+        )
+    )
+    result = await _call(real_server, "list_events", {"limit": 5})
+    assert result == []
 
-    captured: dict = {}
 
-    def capture(request: httpx.Request) -> httpx.Response:
-        captured["body"] = _json.loads(request.content)
-        return httpx.Response(200, json={"data": [{"_id": "e1"}]})
-
-    respx.post(f"{BASE}/stat/event").mock(side_effect=capture)
+@respx.mock
+async def test_real_list_events_forward_compat(real_server: FastMCP) -> None:
+    """If a firmware restores ``GET /stat/event``, records flow through."""
+    respx.get(f"{BASE}/stat/event").mock(
+        return_value=httpx.Response(200, json={"data": [{"_id": "e1"}]})
+    )
     result = await _call(real_server, "list_events", {"limit": 5})
     assert result[0]["_id"] == "e1"
-    assert captured["body"]["_limit"] == 5
-    assert captured["body"]["_sort"] == "-time"
 
 
 @respx.mock
 async def test_real_list_alarms(real_server: FastMCP) -> None:
-    """UniFi Network 9.x 404s the legacy ``GET /stat/alarm?archived=...`` form.
-    The client now POSTs to ``/stat/alarm`` and filters ``archived``
-    client-side, so an active query drops archived records."""
-    import json as _json
-
-    captured: dict = {}
-
-    def capture(request: httpx.Request) -> httpx.Response:
-        captured["body"] = _json.loads(request.content)
-        return httpx.Response(
+    """On a UCG-Fiber (Network 10.4.57) alarms come from
+    ``GET /list/alarm?archived=<bool>`` (HTTP 200, probed live 2026-06-03). The
+    old ``POST /stat/alarm`` form 404s and is abandoned. The active query keeps
+    only non-archived records via the defensive client-side filter."""
+    respx.get(f"{BASE}/list/alarm").mock(
+        return_value=httpx.Response(
             200,
             json={
                 "data": [
@@ -193,11 +196,9 @@ async def test_real_list_alarms(real_server: FastMCP) -> None:
                 ]
             },
         )
-
-    respx.post(f"{BASE}/stat/alarm").mock(side_effect=capture)
+    )
     result = await _call(real_server, "list_alarms", {"limit": 5, "archived": False})
-    assert captured["body"]["_sort"] == "-time"
-    # Only the active alarm survives the client-side archived filter.
+    # Only the active alarm survives the archived filter.
     assert [r["_id"] for r in result] == ["a1"]
     assert result[0]["user"] == "aa:bb:cc:dd:ee:ff"
 
@@ -205,7 +206,7 @@ async def test_real_list_alarms(real_server: FastMCP) -> None:
 @respx.mock
 async def test_real_list_alarms_archived(real_server: FastMCP) -> None:
     """Archived query returns only archived alarms."""
-    respx.post(f"{BASE}/stat/alarm").mock(
+    respx.get(f"{BASE}/list/alarm").mock(
         return_value=httpx.Response(
             200,
             json={


### PR DESCRIPTION
Housekeeping: the v0.12.0 release (real alarm endpoint + graceful-empty events, commit 1a6332f) was tagged and deployed from the fix branch but never merged to main. This brings main in sync with the released code before the v0.13.0 radio-tools work lands on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)