### PR TITLE
fix(ipv6): set_wan_ipv6 enable 400 — use "pd" delegation + consistent PD-size pair (v0.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-06-14
+
+### Fixed
+
+- **`set_wan_ipv6` enable path no longer 400s with `api.err.InvalidValue`.**
+  Enabling DHCPv6-PD on the WAN (`connection_type="dhcpv6"` +
+  `prefix_delegation="prefix-delegation"`) was rejected by the controller on
+  every apply. Two root causes, both fixed and verified live against the
+  UCG-Fiber (UniFi Network 10.4.57):
+  - **Wrong delegation enum value.** The controller stores/accepts
+    `ipv6_wan_delegation_type: "pd"`, not `"prefix-delegation"` (the literal
+    `"prefix-delegation"` is rejected with `InvalidValue`). The tool now accepts
+    the descriptive `"prefix-delegation"` alias (and the raw `"pd"`) and
+    normalises it to the `"pd"` wire value before the PUT.
+  - **Inconsistent PD-size pair.** The live WAN record carries
+    `wan_dhcpv6_pd_size_auto: false` with no `wan_dhcpv6_pd_size` key. When
+    enabling delegation the tool now always emits a self-consistent pair: an
+    explicit `pd_size` pins `wan_dhcpv6_pd_size_auto=false` + that size;
+    enabling delegation with no explicit size pins
+    `wan_dhcpv6_pd_size_auto=true` so the controller auto-sizes.
+  - The strict read-modify-write for all non-IPv6 keys, the disable path, and
+    dual-WAN targeting are unchanged. Added stub + real-mode regression tests
+    pinning the exact accepted payload.
+
 ## [0.15.0] - 2026-06-12
 
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   mcp-unifi:
-    image: ghcr.io/pete-builds/mcp-unifi:0.15.0
+    image: ghcr.io/pete-builds/mcp-unifi:0.15.1
     container_name: mcp-unifi
     restart: unless-stopped
     read_only: true

--- a/docs/site/src/content/docs/tools/get_wan_ipv6/index.md
+++ b/docs/site/src/content/docs/tools/get_wan_ipv6/index.md
@@ -13,8 +13,8 @@ see exactly what you are about to change.
 
 Returns one record per WAN interface with ``name``, ``_id``, and the
 IPv6 keys: ``wan_type_v6`` (connection type: ``disabled``/``dhcpv6``/
-``pppoe``/``static``), ``ipv6_wan_delegation_type`` (``none`` or
-``prefix-delegation``), ``wan_dhcpv6_pd_size_auto``,
+``pppoe``/``static``), ``ipv6_wan_delegation_type`` (``none`` or ``pd``),
+``wan_dhcpv6_pd_size_auto``,
 ``wan_dhcpv6_pd_size`` (present only when PD is configured),
 ``wan_ipv6_dns_preference``, and ``ipv6_setting_preference``.
 

--- a/docs/site/src/content/docs/tools/set_wan_ipv6/index.md
+++ b/docs/site/src/content/docs/tools/set_wan_ipv6/index.md
@@ -39,8 +39,8 @@ set_wan_ipv6(connection_type="dhcpv6", prefix_delegation="prefix-delegation", dr
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `connection_type` | `string` | no | "" | ``"disabled"``, ``"dhcpv6"``, ``"pppoe"``, or ``"static"``. Empty leaves it unchanged. Most ISPs that hand out IPv6 (incl. Empire Access) use ``"dhcpv6"``. |
-| `prefix_delegation` | `string` | no | "" | ``"none"`` or ``"prefix-delegation"``. Empty leaves it unchanged. ``"prefix-delegation"`` is required for your LANs to receive IPv6 subnets. |
-| `pd_size` | `integer` | no | 0 | DHCPv6-PD prefix size (48-64), e.g. ``56``. Only sent when non-zero; sending it also pins ``wan_dhcpv6_pd_size_auto`` to ``false``. Leave 0 to keep the controller's auto sizing. |
+| `prefix_delegation` | `string` | no | "" | ``"none"`` or ``"prefix-delegation"`` (alias for the controller's wire value ``"pd"``; ``"pd"`` is also accepted). Empty leaves it unchanged. Prefix delegation is required for your LANs to receive IPv6 subnets. |
+| `pd_size` | `integer` | no | 0 | DHCPv6-PD prefix size (48-64), e.g. ``56``. When enabling delegation, the controller requires a consistent ``wan_dhcpv6_pd_size_auto`` / ``wan_dhcpv6_pd_size`` pair: a non-zero ``pd_size`` pins ``wan_dhcpv6_pd_size_auto=false`` and sends that size; ``pd_size=0`` while enabling delegation pins ``wan_dhcpv6_pd_size_auto=true`` (controller auto-sizes). Leaving an inconsistent pair on the record is what triggers ``api.err.InvalidValue``, so the tool always emits a consistent pair when delegation is turned on. |
 | `dns_preference` | `string` | no | "" | ``"auto"`` or ``"manual"`` for IPv6 DNS. Empty leaves it unchanged. |
 | `wan_name` | `string` | no | "" | Display name of the WAN to target (e.g. ``"Internet 1"``). Required only on multi-WAN gateways; single-WAN gateways match automatically. |
 | `controller` | `string` | no | "default" | Name of the UniFi controller to target. Defaults to ``"default"``. |

--- a/docs/site/src/data/tool-manifest.json
+++ b/docs/site/src/data/tool-manifest.json
@@ -1709,7 +1709,7 @@
       "name": "get_visitor"
     },
     {
-      "description": "Show the current IPv6 configuration of the WAN uplink(s).\n\nSide effects: None (read-only). Call this before ``set_wan_ipv6`` to\nsee exactly what you are about to change.\n\nReturns one record per WAN interface with ``name``, ``_id``, and the\nIPv6 keys: ``wan_type_v6`` (connection type: ``disabled``/``dhcpv6``/\n``pppoe``/``static``), ``ipv6_wan_delegation_type`` (``none`` or\n``prefix-delegation``), ``wan_dhcpv6_pd_size_auto``,\n``wan_dhcpv6_pd_size`` (present only when PD is configured),\n``wan_ipv6_dns_preference``, and ``ipv6_setting_preference``.\n\nExample: get_wan_ipv6(controller=\"default\")",
+      "description": "Show the current IPv6 configuration of the WAN uplink(s).\n\nSide effects: None (read-only). Call this before ``set_wan_ipv6`` to\nsee exactly what you are about to change.\n\nReturns one record per WAN interface with ``name``, ``_id``, and the\nIPv6 keys: ``wan_type_v6`` (connection type: ``disabled``/``dhcpv6``/\n``pppoe``/``static``), ``ipv6_wan_delegation_type`` (``none`` or ``pd``),\n``wan_dhcpv6_pd_size_auto``,\n``wan_dhcpv6_pd_size`` (present only when PD is configured),\n``wan_ipv6_dns_preference``, and ``ipv6_setting_preference``.\n\nExample: get_wan_ipv6(controller=\"default\")",
       "input_schema": {
         "additionalProperties": false,
         "properties": {
@@ -3079,12 +3079,12 @@
           },
           "pd_size": {
             "default": 0,
-            "description": "DHCPv6-PD prefix size (48-64), e.g. ``56``. Only sent when\nnon-zero; sending it also pins ``wan_dhcpv6_pd_size_auto`` to\n``false``. Leave 0 to keep the controller's auto sizing.",
+            "description": "DHCPv6-PD prefix size (48-64), e.g. ``56``. When enabling\ndelegation, the controller requires a consistent\n``wan_dhcpv6_pd_size_auto`` / ``wan_dhcpv6_pd_size`` pair: a\nnon-zero ``pd_size`` pins ``wan_dhcpv6_pd_size_auto=false`` and\nsends that size; ``pd_size=0`` while enabling delegation pins\n``wan_dhcpv6_pd_size_auto=true`` (controller auto-sizes). Leaving\nan inconsistent pair on the record is what triggers\n``api.err.InvalidValue``, so the tool always emits a consistent\npair when delegation is turned on.",
             "type": "integer"
           },
           "prefix_delegation": {
             "default": "",
-            "description": "``\"none\"`` or ``\"prefix-delegation\"``. Empty\nleaves it unchanged. ``\"prefix-delegation\"`` is required for\nyour LANs to receive IPv6 subnets.",
+            "description": "``\"none\"`` or ``\"prefix-delegation\"`` (alias for\nthe controller's wire value ``\"pd\"``; ``\"pd\"`` is also accepted).\nEmpty leaves it unchanged. Prefix delegation is required for your\nLANs to receive IPv6 subnets.",
             "type": "string"
           },
           "wan_name": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.15.0"
+version = "0.15.1"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_unifi/__init__.py
+++ b/src/mcp_unifi/__init__.py
@@ -19,4 +19,4 @@ a real UCG-Fiber, UDM Pro, or other UniFi OS gateway.
 
 from __future__ import annotations
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/src/mcp_unifi/modules/network/ipv6.py
+++ b/src/mcp_unifi/modules/network/ipv6.py
@@ -9,7 +9,9 @@ Writable keys confirmed on this firmware:
 
 WAN record (``purpose == "wan"``):
     ``wan_type_v6``               connection type: disabled/dhcpv6/pppoe/static
-    ``ipv6_wan_delegation_type``  none / prefix-delegation
+    ``ipv6_wan_delegation_type``  wire values ``none`` / ``pd`` (the tool also
+                                  accepts the ``"prefix-delegation"`` alias and
+                                  normalises it to ``"pd"``)
     ``wan_dhcpv6_pd_size_auto``   bool — auto-size the delegated prefix
     ``wan_dhcpv6_pd_size``        int  — PD size (only when PD + not auto;
                                   absent from the record until PD is enabled,
@@ -53,8 +55,21 @@ logger = logging.getLogger("mcp_unifi.network.ipv6")
 
 #: Accepted WAN IPv6 connection types (``wan_type_v6``).
 _WAN_V6_TYPES: frozenset[str] = frozenset({"disabled", "dhcpv6", "pppoe", "static"})
-#: Accepted WAN prefix-delegation modes (``ipv6_wan_delegation_type``).
-_WAN_DELEGATION_TYPES: frozenset[str] = frozenset({"none", "prefix-delegation"})
+#: WAN prefix-delegation modes the caller may pass, mapped to the **wire value**
+#: the controller actually accepts. UniFi Network 10.4.57 stores the
+#: prefix-delegation mode as ``ipv6_wan_delegation_type: "pd"`` (NOT
+#: ``"prefix-delegation"`` — that literal is rejected with
+#: ``api.err.InvalidValue``). We accept the descriptive ``"prefix-delegation"``
+#: alias for ergonomics and normalise it to ``"pd"`` before the PUT. Probed live
+#: 2026-06-14: ``ipv6_wan_delegation_type: "pd"`` → HTTP 200;
+#: ``"prefix-delegation"`` → HTTP 400 InvalidValue.
+_WAN_DELEGATION_ALIASES: dict[str, str] = {
+    "none": "none",
+    "pd": "pd",
+    "prefix-delegation": "pd",
+}
+#: The wire values the controller stores/accepts for ``ipv6_wan_delegation_type``.
+_WAN_DELEGATION_WIRE: frozenset[str] = frozenset({"none", "pd"})
 #: Accepted LAN interface types (``ipv6_interface_type``).
 _LAN_V6_INTERFACE_TYPES: frozenset[str] = frozenset({"none", "pd", "static"})
 #: Accepted LAN client address-assignment modes.
@@ -132,8 +147,8 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
 
         Returns one record per WAN interface with ``name``, ``_id``, and the
         IPv6 keys: ``wan_type_v6`` (connection type: ``disabled``/``dhcpv6``/
-        ``pppoe``/``static``), ``ipv6_wan_delegation_type`` (``none`` or
-        ``prefix-delegation``), ``wan_dhcpv6_pd_size_auto``,
+        ``pppoe``/``static``), ``ipv6_wan_delegation_type`` (``none`` or ``pd``),
+        ``wan_dhcpv6_pd_size_auto``,
         ``wan_dhcpv6_pd_size`` (present only when PD is configured),
         ``wan_ipv6_dns_preference``, and ``ipv6_setting_preference``.
 
@@ -201,12 +216,19 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             connection_type: ``"disabled"``, ``"dhcpv6"``, ``"pppoe"``, or
                 ``"static"``. Empty leaves it unchanged. Most ISPs that hand
                 out IPv6 (incl. Empire Access) use ``"dhcpv6"``.
-            prefix_delegation: ``"none"`` or ``"prefix-delegation"``. Empty
-                leaves it unchanged. ``"prefix-delegation"`` is required for
-                your LANs to receive IPv6 subnets.
-            pd_size: DHCPv6-PD prefix size (48-64), e.g. ``56``. Only sent when
-                non-zero; sending it also pins ``wan_dhcpv6_pd_size_auto`` to
-                ``false``. Leave 0 to keep the controller's auto sizing.
+            prefix_delegation: ``"none"`` or ``"prefix-delegation"`` (alias for
+                the controller's wire value ``"pd"``; ``"pd"`` is also accepted).
+                Empty leaves it unchanged. Prefix delegation is required for your
+                LANs to receive IPv6 subnets.
+            pd_size: DHCPv6-PD prefix size (48-64), e.g. ``56``. When enabling
+                delegation, the controller requires a consistent
+                ``wan_dhcpv6_pd_size_auto`` / ``wan_dhcpv6_pd_size`` pair: a
+                non-zero ``pd_size`` pins ``wan_dhcpv6_pd_size_auto=false`` and
+                sends that size; ``pd_size=0`` while enabling delegation pins
+                ``wan_dhcpv6_pd_size_auto=true`` (controller auto-sizes). Leaving
+                an inconsistent pair on the record is what triggers
+                ``api.err.InvalidValue``, so the tool always emits a consistent
+                pair when delegation is turned on.
             dns_preference: ``"auto"`` or ``"manual"`` for IPv6 DNS. Empty
                 leaves it unchanged.
             wan_name: Display name of the WAN to target (e.g. ``"Internet 1"``).
@@ -222,11 +244,13 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 f"invalid connection_type {connection_type!r}: "
                 "use disabled, dhcpv6, pppoe, or static"
             )
-        pd = prefix_delegation.strip().lower()
-        if pd and pd not in _WAN_DELEGATION_TYPES:
+        pd_input = prefix_delegation.strip().lower()
+        if pd_input and pd_input not in _WAN_DELEGATION_ALIASES:
             return err(
                 f"invalid prefix_delegation {prefix_delegation!r}: use none or prefix-delegation"
             )
+        # Normalise the caller-facing alias to the controller's wire value.
+        pd = _WAN_DELEGATION_ALIASES.get(pd_input, "") if pd_input else ""
         dns = dns_preference.strip().lower()
         if dns and dns not in _PREFERENCE:
             return err(f"invalid dns_preference {dns_preference!r}: use auto or manual")
@@ -238,9 +262,18 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             patch["wan_type_v6"] = ct
         if pd:
             patch["ipv6_wan_delegation_type"] = pd
+        # The live WAN record can carry an inconsistent ``wan_dhcpv6_pd_size_auto:
+        # false`` with no ``wan_dhcpv6_pd_size`` key. When we turn delegation ON
+        # (``pd == "pd"``) we must emit a self-consistent auto/size pair or the
+        # controller rejects the merged record with ``api.err.InvalidValue``.
+        # An explicit ``pd_size`` always pins ``pd_size_auto=false`` + that size;
+        # otherwise (enabling delegation with no explicit size) pin
+        # ``pd_size_auto=true`` so the controller auto-sizes.
         if pd_size:
             patch["wan_dhcpv6_pd_size"] = pd_size
             patch["wan_dhcpv6_pd_size_auto"] = False
+        elif pd == "pd":
+            patch["wan_dhcpv6_pd_size_auto"] = True
         if dns:
             patch["wan_ipv6_dns_preference"] = dns
         if not patch:

--- a/tests/network/test_ipv6.py
+++ b/tests/network/test_ipv6.py
@@ -76,7 +76,8 @@ async def test_set_wan_ipv6_dry_run_diff(stub_server: FastMCP, stub_state: StubS
     assert upd["action"] == "set_wan_ipv6"
     assert upd["before"]["wan_type_v6"] == "disabled"
     assert upd["after"]["wan_type_v6"] == "dhcpv6"
-    assert upd["after"]["ipv6_wan_delegation_type"] == "prefix-delegation"
+    # The "prefix-delegation" alias normalises to the controller's wire value "pd".
+    assert upd["after"]["ipv6_wan_delegation_type"] == "pd"
     assert upd["after"]["wan_dhcpv6_pd_size"] == 56
     assert upd["after"]["wan_dhcpv6_pd_size_auto"] is False
     assert "blast_radius" in result
@@ -111,6 +112,141 @@ async def test_set_wan_ipv6_rejects_bad_type(stub_server: FastMCP) -> None:
 async def test_set_wan_ipv6_rejects_bad_pd_size(stub_server: FastMCP) -> None:
     result = await _call(stub_server, "set_wan_ipv6", {"pd_size": 32})
     assert "error" in result
+
+
+async def test_set_wan_ipv6_alias_normalises_to_pd(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    """The friendly ``"prefix-delegation"`` alias must hit the wire value ``"pd"``.
+
+    Regression: UniFi Network 10.4.57 rejects ``ipv6_wan_delegation_type:
+    "prefix-delegation"`` with ``api.err.InvalidValue``; the only accepted value
+    is ``"pd"``.
+    """
+    result = await _call(
+        stub_server,
+        "set_wan_ipv6",
+        {"connection_type": "dhcpv6", "prefix_delegation": "prefix-delegation"},
+    )
+    assert result["updated"] is True
+    wan = next(n for n in stub_state.networks if n.get("purpose") == "wan")
+    assert wan["ipv6_wan_delegation_type"] == "pd"
+
+
+async def test_set_wan_ipv6_accepts_pd_wire_value(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    """Passing the raw wire value ``"pd"`` works too."""
+    result = await _call(
+        stub_server,
+        "set_wan_ipv6",
+        {"connection_type": "dhcpv6", "prefix_delegation": "pd"},
+    )
+    assert result["updated"] is True
+    wan = next(n for n in stub_state.networks if n.get("purpose") == "wan")
+    assert wan["ipv6_wan_delegation_type"] == "pd"
+
+
+async def test_set_wan_ipv6_enable_pd_without_size_pins_auto_true(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    """Enabling delegation with no explicit ``pd_size`` must emit a consistent
+    auto/size pair: ``wan_dhcpv6_pd_size_auto=True`` (controller auto-sizes).
+
+    Regression for the ``api.err.InvalidValue`` 400: the live WAN record carries
+    ``wan_dhcpv6_pd_size_auto: false`` with NO ``wan_dhcpv6_pd_size`` key. Turning
+    delegation on without normalising that pair produces an internally
+    inconsistent record the controller rejects.
+    """
+    result = await _call(
+        stub_server,
+        "set_wan_ipv6",
+        {"connection_type": "dhcpv6", "prefix_delegation": "prefix-delegation"},
+    )
+    assert result["updated"] is True
+    wan = next(n for n in stub_state.networks if n.get("purpose") == "wan")
+    assert wan["wan_dhcpv6_pd_size_auto"] is True
+    # No explicit size is sent when auto-sizing.
+    assert "wan_dhcpv6_pd_size" not in wan
+
+
+async def test_set_wan_ipv6_enable_pd_with_size_pins_auto_false(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    """An explicit ``pd_size`` pins ``wan_dhcpv6_pd_size_auto=False`` + that size,
+    a self-consistent pair the controller accepts."""
+    result = await _call(
+        stub_server,
+        "set_wan_ipv6",
+        {"connection_type": "dhcpv6", "prefix_delegation": "prefix-delegation", "pd_size": 56},
+    )
+    assert result["updated"] is True
+    wan = next(n for n in stub_state.networks if n.get("purpose") == "wan")
+    assert wan["wan_dhcpv6_pd_size_auto"] is False
+    assert wan["wan_dhcpv6_pd_size"] == 56
+
+
+@respx.mock
+async def test_real_set_wan_ipv6_enable_pd_puts_consistent_payload(
+    real_server: FastMCP,
+) -> None:
+    """The live PUT body the controller accepts: delegation wire value ``"pd"``
+    plus a consistent ``wan_dhcpv6_pd_size_auto``/``wan_dhcpv6_pd_size`` pair.
+
+    This pins the exact payload shape that fixed the ``api.err.InvalidValue``
+    400. The starting record reproduces the live inconsistency
+    (``wan_dhcpv6_pd_size_auto: False`` with no size key).
+    """
+    import json as _json
+
+    respx.get(f"{BASE}/rest/networkconf").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "_id": "wan1",
+                        "name": "Internet 1",
+                        "purpose": "wan",
+                        "wan_type_v6": "disabled",
+                        "ipv6_wan_delegation_type": "none",
+                        "wan_dhcpv6_pd_size_auto": False,
+                    }
+                ]
+            },
+        )
+    )
+    put_route = respx.put(f"{BASE}/rest/networkconf/wan1").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "_id": "wan1",
+                        "wan_type_v6": "dhcpv6",
+                        "ipv6_wan_delegation_type": "pd",
+                        "wan_dhcpv6_pd_size_auto": False,
+                        "wan_dhcpv6_pd_size": 56,
+                    }
+                ]
+            },
+        )
+    )
+    result = await _call(
+        real_server,
+        "set_wan_ipv6",
+        {"connection_type": "dhcpv6", "prefix_delegation": "prefix-delegation", "pd_size": 56},
+    )
+    assert result["updated"] is True
+    assert put_route.called
+    body = _json.loads(put_route.calls[0].request.content)
+    # Exact payload the live controller accepts (probed 2026-06-14):
+    assert body == {
+        "wan_type_v6": "dhcpv6",
+        "ipv6_wan_delegation_type": "pd",
+        "wan_dhcpv6_pd_size": 56,
+        "wan_dhcpv6_pd_size_auto": False,
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`set_wan_ipv6` enable returned HTTP 400 `api.err.InvalidValue` on every live apply against the UCG-Fiber (UniFi Network 10.4.57), on both `pd_size=56` and `pd_size=60` and even with an explicit size. The `dry_run` preview was clean (it does not replicate server-side validation).

## Root causes (both verified live against the controller)

1. **Wrong delegation enum value.** The controller stores/accepts `ipv6_wan_delegation_type: "pd"`, **not** `"prefix-delegation"`. The literal `"prefix-delegation"` is rejected with `InvalidValue`. Probed live 2026-06-14: `"pd"` → HTTP 200; `"prefix-delegation"` → HTTP 400.
2. **Inconsistent PD-size pair.** The live WAN record carries `wan_dhcpv6_pd_size_auto: false` with **no** `wan_dhcpv6_pd_size` key. Enabling delegation without normalising that pair leaves an internally inconsistent record.

## Fix

- Accept the descriptive `"prefix-delegation"` alias (and raw `"pd"`) and normalise to the `"pd"` wire value before the PUT.
- When enabling delegation, always emit a consistent pair: explicit `pd_size` → `auto=false` + size; no size → `auto=true` (controller auto-sizes).
- Strict read-modify-write for non-IPv6 keys, the disable path, and dual-WAN targeting are untouched.

## Verification

Live single apply through the fixed code path enabled WAN1 "Internet 1" IPv6 (`dhcpv6` + `pd` + `/56`, HTTP 200). The gateway's WAN1 interface received a global IPv6 from Empire Access: `2606:380:2000::dce`.

## Tests

Adds stub + real-mode regression tests pinning the exact accepted payload (delegation value `"pd"`, consistent auto/size pair). Full suite green (868 passed), ruff + mypy --strict clean. Manifest regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)