### PR TITLE
fix(ipv6): set_lan_ipv6 PD enable 400 -> emit ipv6_pd_interface WAN binding (v0.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-06-14
+
+### Fixed
+
+- **`set_lan_ipv6` PD enable path no longer 400s with
+  `api.err.PdRequiresAssignedDhcpv6Wan`.** Enabling prefix delegation on a LAN
+  (`interface_type="pd"`) was rejected by the controller on every apply. Root
+  cause, fixed and verified live against the UCG-Fiber (UniFi Network 10.4.57):
+  - **Missing WAN-uplink binding.** A PD LAN networkconf must reference which
+    DHCPv6 WAN's delegation it draws from via `ipv6_pd_interface` (the WAN's
+    networkgroup, lowercased — `"wan"` on this gateway). The tool emitted only
+    `ipv6_interface_type="pd"` and omitted the binding, so the controller
+    rejected the merged record. Probed live: `ipv6_interface_type=pd` alone →
+    HTTP 400 `PdRequiresAssignedDhcpv6Wan`; adding `ipv6_pd_interface="wan"` →
+    HTTP 200 and the LAN receives a global /64.
+  - The fix auto-resolves the binding from the WAN that actually has DHCPv6-PD
+    enabled (`ipv6_wan_delegation_type=="pd"` + non-disabled `wan_type_v6`) and
+    injects `ipv6_pd_interface` into the patch. When no WAN delegates a prefix,
+    the tool returns a clear error pointing at `set_wan_ipv6` instead of letting
+    the controller 400.
+  - **New optional `prefix_id` param.** A hex sub-prefix id selecting which /64
+    to carve from the delegated /56, sent as `ipv6_pd_prefixid` (only with
+    `interface_type="pd"`). On UniFi Network 10.4.57 the controller auto-carves
+    the sub-prefix and ignores this value; it is accepted for forward/
+    cross-firmware compatibility.
+  - Strict read-modify-write for all non-IPv6 keys and the `none`/`static`
+    paths are unchanged. Added stub + real-mode regression tests pinning the
+    WAN-binding payload, the `prefix_id` forwarding, and the no-delegation
+    error.
+  - **Live-verified:** the Default/MGMT LAN was enabled end-to-end through the
+    fixed code path. The gateway carved `2606:380:2000:4ad::/64` from the
+    delegated `2606:380:2000::/56` (gateway LAN address
+    `2606:380:2000:4ad::1`) and a real client picked up the global address
+    `2606:380:2000:4ad:a6bb:6dff:feac:287c`. Default IPv6 is left enabled.
+
 ## [0.15.1] - 2026-06-14
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   mcp-unifi:
-    image: ghcr.io/pete-builds/mcp-unifi:0.15.1
+    image: ghcr.io/pete-builds/mcp-unifi:0.15.2
     container_name: mcp-unifi
     restart: unless-stopped
     read_only: true

--- a/docs/site/src/content/docs/tools/set_lan_ipv6/index.md
+++ b/docs/site/src/content/docs/tools/set_lan_ipv6/index.md
@@ -21,6 +21,15 @@ Side effects:
 - Mutates controller state. Use dry_run=True to preview the before/
   after diff without applying.
 
+Prefix-delegation binding: when ``interface_type="pd"`` the controller
+REQUIRES the LAN to reference which DHCPv6 WAN's delegation to draw
+from. ``ipv6_interface_type=pd`` on its own returns HTTP 400
+``api.err.PdRequiresAssignedDhcpv6Wan``. This tool auto-binds the LAN to
+the WAN that actually has DHCPv6-PD enabled (on a single-uplink gateway
+that is the only internet uplink) by emitting ``ipv6_pd_interface`` =
+that WAN's networkgroup (e.g. ``"wan"``). No WAN with PD enabled → a
+clear error instead of a controller 400.
+
 Read first: call ``list_networks`` to find the ``network_id`` and see
 the current ``ipv6_*`` state (now surfaced inline).
 
@@ -35,11 +44,12 @@ set_lan_ipv6(network_id="65f...", interface_type="pd", ra_enabled=True, dry_run=
 | Parameter | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `network_id` | `string` | yes | — | The ``_id`` from ``list_networks`` (a LAN/VLAN, not a WAN). |
-| `interface_type` | `string` | no | "" | ``"none"``, ``"pd"`` (use the WAN-delegated prefix), or ``"static"``. Empty leaves it unchanged. |
+| `interface_type` | `string` | no | "" | ``"none"``, ``"pd"`` (use the WAN-delegated prefix), or ``"static"``. Empty leaves it unchanged. When set to ``"pd"`` the WAN binding is added automatically. |
 | `ra_enabled` | `boolean | null` | no | null | ``True``/``False`` to toggle IPv6 Router Advertisements (SLAAC). ``None`` (default) leaves it unchanged. |
 | `address_assignment` | `string` | no | "" | ``"slaac"`` or ``"dhcpv6"``. Empty leaves it unchanged. |
 | `dns_auto` | `boolean | null` | no | null | ``True`` to advertise the gateway as DNS, ``False`` to use explicit servers from ``dns_servers``. ``None`` leaves it unchanged. |
 | `dns_servers` | `array | null` | no | null | Up to four IPv6 DNS server addresses, applied as ``dhcpdv6_dns_1..4`` when ``dns_auto=False``. ``None`` leaves them unchanged. |
+| `prefix_id` | `string` | no | "" | Optional hex sub-prefix id (e.g. ``"0"``, ``"1"``) selecting which /64 to carve from the delegated /56, so multiple PD LANs don't collide. Only sent when ``interface_type="pd"``. Empty (default) lets the controller auto-carve a sub-prefix. Note: on UniFi Network 10.4.57 the controller auto-assigns the sub-prefix and ignores this value; it is accepted for forward/ cross-firmware compatibility. |
 | `controller` | `string` | no | "default" | Name of the UniFi controller to target. Defaults to ``"default"``. |
 | `dry_run` | `boolean` | no | false | Preview the before/after diff without applying it. |
 

--- a/docs/site/src/data/tool-manifest.json
+++ b/docs/site/src/data/tool-manifest.json
@@ -2691,7 +2691,7 @@
       "name": "set_camera_recording_mode"
     },
     {
-      "description": "Set the IPv6 configuration of one LAN/VLAN network.\n\nSide effects:\n- Changes how this network gets and advertises IPv6. Turning on\n  ``interface_type=\"pd\"`` plus ``ra_enabled=True`` is what makes the\n  LAN's clients receive global IPv6 addresses from the prefix\n  delegated by the WAN. Toggling router advertisements\n  (``ra_enabled``) or the address-assignment mode causes clients on\n  this network to re-acquire IPv6; IPv4 is unaffected.\n- Only the IPv6 keys you supply change; every other field on the\n  network record is read first and written back unchanged (strict\n  read-modify-write).\n- Mutates controller state. Use dry_run=True to preview the before/\n  after diff without applying.\n\nRead first: call ``list_networks`` to find the ``network_id`` and see\nthe current ``ipv6_*`` state (now surfaced inline).\n\nExample: set_lan_ipv6(network_id=\"65f...\", interface_type=\"pd\", ra_enabled=True, dry_run=True)",
+      "description": "Set the IPv6 configuration of one LAN/VLAN network.\n\nSide effects:\n- Changes how this network gets and advertises IPv6. Turning on\n  ``interface_type=\"pd\"`` plus ``ra_enabled=True`` is what makes the\n  LAN's clients receive global IPv6 addresses from the prefix\n  delegated by the WAN. Toggling router advertisements\n  (``ra_enabled``) or the address-assignment mode causes clients on\n  this network to re-acquire IPv6; IPv4 is unaffected.\n- Only the IPv6 keys you supply change; every other field on the\n  network record is read first and written back unchanged (strict\n  read-modify-write).\n- Mutates controller state. Use dry_run=True to preview the before/\n  after diff without applying.\n\nPrefix-delegation binding: when ``interface_type=\"pd\"`` the controller\nREQUIRES the LAN to reference which DHCPv6 WAN's delegation to draw\nfrom. ``ipv6_interface_type=pd`` on its own returns HTTP 400\n``api.err.PdRequiresAssignedDhcpv6Wan``. This tool auto-binds the LAN to\nthe WAN that actually has DHCPv6-PD enabled (on a single-uplink gateway\nthat is the only internet uplink) by emitting ``ipv6_pd_interface`` =\nthat WAN's networkgroup (e.g. ``\"wan\"``). No WAN with PD enabled \u2192 a\nclear error instead of a controller 400.\n\nRead first: call ``list_networks`` to find the ``network_id`` and see\nthe current ``ipv6_*`` state (now surfaced inline).\n\nExample: set_lan_ipv6(network_id=\"65f...\", interface_type=\"pd\", ra_enabled=True, dry_run=True)",
       "input_schema": {
         "additionalProperties": false,
         "properties": {
@@ -2739,11 +2739,16 @@
           },
           "interface_type": {
             "default": "",
-            "description": "``\"none\"``, ``\"pd\"`` (use the WAN-delegated\nprefix), or ``\"static\"``. Empty leaves it unchanged.",
+            "description": "``\"none\"``, ``\"pd\"`` (use the WAN-delegated\nprefix), or ``\"static\"``. Empty leaves it unchanged. When set to\n``\"pd\"`` the WAN binding is added automatically.",
             "type": "string"
           },
           "network_id": {
             "description": "The ``_id`` from ``list_networks`` (a LAN/VLAN, not a\nWAN).",
+            "type": "string"
+          },
+          "prefix_id": {
+            "default": "",
+            "description": "Optional hex sub-prefix id (e.g. ``\"0\"``, ``\"1\"``)\nselecting which /64 to carve from the delegated /56, so multiple\nPD LANs don't collide. Only sent when ``interface_type=\"pd\"``.\nEmpty (default) lets the controller auto-carve a sub-prefix.\nNote: on UniFi Network 10.4.57 the controller auto-assigns the\nsub-prefix and ignores this value; it is accepted for forward/\ncross-firmware compatibility.",
             "type": "string"
           },
           "ra_enabled": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.15.1"
+version = "0.15.2"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/mcp_unifi/__init__.py
+++ b/src/mcp_unifi/__init__.py
@@ -19,4 +19,4 @@ a real UCG-Fiber, UDM Pro, or other UniFi OS gateway.
 
 from __future__ import annotations
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/src/mcp_unifi/clients/stubs.py
+++ b/src/mcp_unifi/clients/stubs.py
@@ -149,9 +149,16 @@ def _seed_networks() -> list[UniFiRecord]:
             "attr_no_delete": True,
             "site_id": "default",
             "enabled": True,
-            # IPv6 keys mirror a real UCG-Fiber WAN networkconf record.
-            "wan_type_v6": "disabled",
-            "ipv6_wan_delegation_type": "none",
+            # IPv6 keys mirror a real UCG-Fiber WAN networkconf record with
+            # DHCPv6 prefix delegation enabled (the live gateway state). A LAN
+            # can only enable PD when a WAN actually delegates a prefix, so the
+            # stub WAN advertises PD so stub-mode PD-enable exercises the binding.
+            "wan_networkgroup": "WAN",
+            "wan_type_v6": "dhcpv6",
+            "ipv6_wan_delegation_type": "pd",
+            # No explicit size key: mirrors the live record's
+            # auto=false-with-no-size inconsistency the set_wan_ipv6 fix
+            # normalises. The PD-LAN binding only needs delegation_type=="pd".
             "wan_dhcpv6_pd_size_auto": False,
             "wan_ipv6_dns_preference": "auto",
             "ipv6_setting_preference": "auto",

--- a/src/mcp_unifi/modules/network/ipv6.py
+++ b/src/mcp_unifi/modules/network/ipv6.py
@@ -21,6 +21,22 @@ WAN record (``purpose == "wan"``):
 
 LAN record (``purpose in {"corporate", "guest"}``):
     ``ipv6_interface_type``            none / pd / static
+    ``ipv6_pd_interface``              str  — the WAN networkgroup whose DHCPv6-PD
+                                       delegation this LAN draws from (wire value
+                                       ``"wan"`` on a single-uplink gateway). **A
+                                       PD LAN is REJECTED without this binding**:
+                                       ``ipv6_interface_type=pd`` alone returns
+                                       HTTP 400 ``api.err.PdRequiresAssignedDhcpv6Wan``
+                                       (probed live 2026-06-14). Adding
+                                       ``ipv6_pd_interface="wan"`` → HTTP 200 and
+                                       the LAN receives a global /64.
+    ``ipv6_pd_prefixid``               str  — hex sub-prefix id selecting which /64
+                                       to carve from the delegated /56. Accepted on
+                                       the PUT but **not persisted** on UniFi
+                                       Network 10.4.57 (the controller auto-carves
+                                       the sub-prefix; probed live 2026-06-14). Sent
+                                       only when the caller pins one, for forward/
+                                       cross-firmware compatibility.
     ``ipv6_client_address_assignment`` slaac / dhcpv6
     ``ipv6_ra_enabled``                bool — router advertisements
     ``dhcpdv6_dns_auto``               bool
@@ -95,6 +111,33 @@ _PD_SIZE_MAX = 64
 def _ipv6_view(record: UniFiRecord, keys: tuple[str, ...]) -> dict[str, Any]:
     """Project the IPv6-relevant keys out of a networkconf record."""
     return {k: record.get(k) for k in keys if k in record}
+
+
+def _pd_wan_binding(networks: list[UniFiRecord]) -> str | None:
+    """Return the ``ipv6_pd_interface`` wire value for the PD-enabled WAN.
+
+    A PD LAN must reference WHICH DHCPv6 WAN's delegation it draws from via
+    ``ipv6_pd_interface`` (the WAN's networkgroup, lowercased — e.g. ``"wan"``).
+    We auto-target the WAN that actually has prefix-delegation turned on
+    (``ipv6_wan_delegation_type == "pd"`` and a non-disabled
+    ``wan_type_v6``); on a single-uplink gateway that is "Internet 1" with
+    ``wan_networkgroup == "WAN"`` → ``"wan"``.
+
+    Returns the lowercased networkgroup, or ``None`` when no WAN has DHCPv6-PD
+    enabled (in which case enabling PD on a LAN would 400 anyway and the caller
+    surfaces a clear error instead of letting the controller reject it).
+    """
+    for wan in networks:
+        if not isinstance(wan, dict) or wan.get("purpose") != "wan":
+            continue
+        if wan.get("ipv6_wan_delegation_type") != "pd":
+            continue
+        if wan.get("wan_type_v6") in (None, "", "disabled"):
+            continue
+        group = wan.get("wan_networkgroup")
+        if isinstance(group, str) and group:
+            return group.lower()
+    return None
 
 
 def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> None:
@@ -337,6 +380,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         address_assignment: str = "",
         dns_auto: bool | None = None,
         dns_servers: list[str] | None = None,
+        prefix_id: str = "",
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:
@@ -355,6 +399,15 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         - Mutates controller state. Use dry_run=True to preview the before/
           after diff without applying.
 
+        Prefix-delegation binding: when ``interface_type="pd"`` the controller
+        REQUIRES the LAN to reference which DHCPv6 WAN's delegation to draw
+        from. ``ipv6_interface_type=pd`` on its own returns HTTP 400
+        ``api.err.PdRequiresAssignedDhcpv6Wan``. This tool auto-binds the LAN to
+        the WAN that actually has DHCPv6-PD enabled (on a single-uplink gateway
+        that is the only internet uplink) by emitting ``ipv6_pd_interface`` =
+        that WAN's networkgroup (e.g. ``"wan"``). No WAN with PD enabled → a
+        clear error instead of a controller 400.
+
         Read first: call ``list_networks`` to find the ``network_id`` and see
         the current ``ipv6_*`` state (now surfaced inline).
 
@@ -364,7 +417,8 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             network_id: The ``_id`` from ``list_networks`` (a LAN/VLAN, not a
                 WAN).
             interface_type: ``"none"``, ``"pd"`` (use the WAN-delegated
-                prefix), or ``"static"``. Empty leaves it unchanged.
+                prefix), or ``"static"``. Empty leaves it unchanged. When set to
+                ``"pd"`` the WAN binding is added automatically.
             ra_enabled: ``True``/``False`` to toggle IPv6 Router
                 Advertisements (SLAAC). ``None`` (default) leaves it unchanged.
             address_assignment: ``"slaac"`` or ``"dhcpv6"``. Empty leaves it
@@ -375,6 +429,13 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             dns_servers: Up to four IPv6 DNS server addresses, applied as
                 ``dhcpdv6_dns_1..4`` when ``dns_auto=False``. ``None`` leaves
                 them unchanged.
+            prefix_id: Optional hex sub-prefix id (e.g. ``"0"``, ``"1"``)
+                selecting which /64 to carve from the delegated /56, so multiple
+                PD LANs don't collide. Only sent when ``interface_type="pd"``.
+                Empty (default) lets the controller auto-carve a sub-prefix.
+                Note: on UniFi Network 10.4.57 the controller auto-assigns the
+                sub-prefix and ignores this value; it is accepted for forward/
+                cross-firmware compatibility.
             controller: Name of the UniFi controller to target. Defaults to
                 ``"default"``.
             dry_run: Preview the before/after diff without applying it.
@@ -387,6 +448,9 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(f"invalid address_assignment {address_assignment!r}: use slaac or dhcpv6")
         if dns_servers is not None and len(dns_servers) > 4:
             return err("dns_servers accepts at most 4 addresses")
+        pid = prefix_id.strip().lower()
+        if pid and it != "pd":
+            return err("prefix_id is only valid when interface_type='pd'")
 
         patch: dict[str, Any] = {}
         if it:
@@ -408,12 +472,37 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 "address_assignment, dns_auto, dns_servers"
             )
 
+        try:
+            backend = resolve_backend(registry, controller)
+            networks = await backend.list_networks()
+        except UniFiError as exc:
+            logger.exception("set_lan_ipv6 failed", extra={"network_id": network_id})
+            return err(str(exc))
+
+        # Enabling PD on a LAN requires the WAN-uplink binding + (optionally) a
+        # prefix-id, or the controller rejects the record with
+        # ``api.err.PdRequiresAssignedDhcpv6Wan``. Resolve the binding from the
+        # PD-enabled WAN and inject it into the patch.
+        if it == "pd":
+            binding = _pd_wan_binding(networks)
+            if binding is None:
+                return err(
+                    "cannot enable PD on this LAN: no WAN has DHCPv6 prefix "
+                    "delegation enabled. Enable it on the WAN first with "
+                    "set_wan_ipv6(connection_type='dhcpv6', "
+                    "prefix_delegation='prefix-delegation')."
+                )
+            patch["ipv6_pd_interface"] = binding
+            if pid:
+                patch["ipv6_pd_prefixid"] = pid
+
         # Tracked keys for the before/after view: the patch keys plus the
         # stable identifiers callers expect to see move.
         view_keys = tuple(
             dict.fromkeys(
                 (
                     "ipv6_interface_type",
+                    "ipv6_pd_interface",
                     "ipv6_ra_enabled",
                     "ipv6_client_address_assignment",
                     "dhcpdv6_dns_auto",
@@ -422,10 +511,12 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             )
         )
         try:
-            backend = resolve_backend(registry, controller)
-            found = await _find_network(backend, network_id=network_id)
-            if isinstance(found, str):
-                return err(found)
+            found = next(
+                (n for n in networks if isinstance(n, dict) and n.get("_id") == network_id),
+                None,
+            )
+            if found is None:
+                return err(f"network {network_id} not found")
             if found.get("purpose") == "wan":
                 return err(f"network {network_id} is a WAN; use set_wan_ipv6 for WAN IPv6")
             before = _ipv6_view(found, view_keys)

--- a/tests/network/test_ipv6.py
+++ b/tests/network/test_ipv6.py
@@ -39,8 +39,9 @@ async def test_get_wan_ipv6_returns_keys(stub_server: FastMCP) -> None:
     assert len(wans) == 1
     wan = wans[0]
     assert wan["name"] == "Internet 1"
-    assert wan["wan_type_v6"] == "disabled"
-    assert wan["ipv6_wan_delegation_type"] == "none"
+    # The stub WAN mirrors the live UCG-Fiber: DHCPv6 with prefix delegation on.
+    assert wan["wan_type_v6"] == "dhcpv6"
+    assert wan["ipv6_wan_delegation_type"] == "pd"
     assert "_id" in wan
 
 
@@ -74,7 +75,9 @@ async def test_set_wan_ipv6_dry_run_diff(stub_server: FastMCP, stub_state: StubS
     assert result["dry_run"] is True
     upd = result["would_update"]
     assert upd["action"] == "set_wan_ipv6"
-    assert upd["before"]["wan_type_v6"] == "disabled"
+    # Stub WAN starts DHCPv6+PD (mirrors the live gateway); the dry-run shows the
+    # would-be after-state with a consistent PD-size pair.
+    assert upd["before"]["wan_type_v6"] == "dhcpv6"
     assert upd["after"]["wan_type_v6"] == "dhcpv6"
     # The "prefix-delegation" alias normalises to the controller's wire value "pd".
     assert upd["after"]["ipv6_wan_delegation_type"] == "pd"
@@ -280,7 +283,40 @@ async def test_set_lan_ipv6_applies(stub_server: FastMCP, stub_state: StubState)
     )
     assert result["updated"] is True
     assert result["after"]["ipv6_interface_type"] == "pd"
-    assert result["after"]["ipv6_client_address_assignment"] == "dhcpv6"
+    # PD enable auto-binds to the DHCPv6-PD WAN (mandatory or the controller 400s).
+    assert result["after"]["ipv6_pd_interface"] == "wan"
+    lan = next(n for n in stub_state.networks if n.get("_id") == lan_id)
+    assert lan["ipv6_pd_interface"] == "wan"
+
+
+async def test_set_lan_ipv6_pd_dry_run_shows_binding(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    """Dry-run of a PD enable must surface the WAN binding in the after-state."""
+    lan_id = _lan_id(stub_state)
+    result = await _call(
+        stub_server,
+        "set_lan_ipv6",
+        {"network_id": lan_id, "interface_type": "pd", "prefix_id": "0", "dry_run": True},
+    )
+    upd = result["would_update"]
+    assert upd["after"]["ipv6_interface_type"] == "pd"
+    assert upd["after"]["ipv6_pd_interface"] == "wan"
+    assert upd["after"]["ipv6_pd_prefixid"] == "0"
+
+
+async def test_set_lan_ipv6_prefix_id_requires_pd(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    """``prefix_id`` is only meaningful when enabling PD; reject it otherwise."""
+    lan_id = _lan_id(stub_state)
+    result = await _call(
+        stub_server,
+        "set_lan_ipv6",
+        {"network_id": lan_id, "ra_enabled": True, "prefix_id": "1"},
+    )
+    assert "error" in result
+    assert "prefix_id" in result["error"]
 
 
 async def test_set_lan_ipv6_explicit_dns(stub_server: FastMCP, stub_state: StubState) -> None:
@@ -338,7 +374,15 @@ async def test_set_lan_ipv6_rejects_bad_interface_type(
 
 
 @respx.mock
-async def test_real_set_lan_ipv6_puts_only_ipv6_keys(real_server: FastMCP) -> None:
+async def test_real_set_lan_ipv6_pd_puts_wan_binding(real_server: FastMCP) -> None:
+    """Enabling PD on a LAN must emit the ``ipv6_pd_interface`` WAN binding.
+
+    Regression for ``api.err.PdRequiresAssignedDhcpv6Wan`` (probed live
+    2026-06-14): ``ipv6_interface_type=pd`` alone is rejected; the controller
+    requires the LAN to reference the DHCPv6-PD WAN via ``ipv6_pd_interface``
+    (the WAN's networkgroup, lowercased — ``"wan"``). The tool auto-resolves it
+    from the PD-enabled WAN.
+    """
     respx.get(f"{BASE}/rest/networkconf").mock(
         return_value=httpx.Response(
             200,
@@ -351,7 +395,15 @@ async def test_real_set_lan_ipv6_puts_only_ipv6_keys(real_server: FastMCP) -> No
                         "ip_subnet": "192.168.1.1/24",
                         "ipv6_interface_type": "none",
                         "ipv6_ra_enabled": False,
-                    }
+                    },
+                    {
+                        "_id": "wan1",
+                        "name": "Internet 1",
+                        "purpose": "wan",
+                        "wan_networkgroup": "WAN",
+                        "wan_type_v6": "dhcpv6",
+                        "ipv6_wan_delegation_type": "pd",
+                    },
                 ]
             },
         )
@@ -359,7 +411,16 @@ async def test_real_set_lan_ipv6_puts_only_ipv6_keys(real_server: FastMCP) -> No
     put_route = respx.put(f"{BASE}/rest/networkconf/lan1").mock(
         return_value=httpx.Response(
             200,
-            json={"data": [{"_id": "lan1", "ipv6_interface_type": "pd", "ipv6_ra_enabled": True}]},
+            json={
+                "data": [
+                    {
+                        "_id": "lan1",
+                        "ipv6_interface_type": "pd",
+                        "ipv6_pd_interface": "wan",
+                        "ipv6_ra_enabled": True,
+                    }
+                ]
+            },
         )
     )
     result = await _call(
@@ -374,7 +435,102 @@ async def test_real_set_lan_ipv6_puts_only_ipv6_keys(real_server: FastMCP) -> No
 
     body = _json.loads(sent.content)
     # Strict read-modify-write: only IPv6 keys in the patch, no ip_subnet etc.
-    assert body == {"ipv6_interface_type": "pd", "ipv6_ra_enabled": True}
+    # The PD path adds the mandatory WAN binding (auto-resolved from the WAN).
+    assert body == {
+        "ipv6_interface_type": "pd",
+        "ipv6_ra_enabled": True,
+        "ipv6_pd_interface": "wan",
+    }
+
+
+@respx.mock
+async def test_real_set_lan_ipv6_pd_with_prefix_id(real_server: FastMCP) -> None:
+    """An explicit ``prefix_id`` is forwarded as ``ipv6_pd_prefixid`` alongside
+    the WAN binding (for firmware that honours manual sub-prefix selection)."""
+    respx.get(f"{BASE}/rest/networkconf").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "_id": "lan1",
+                        "name": "TRUSTED",
+                        "purpose": "corporate",
+                        "ipv6_interface_type": "none",
+                    },
+                    {
+                        "_id": "wan1",
+                        "name": "Internet 1",
+                        "purpose": "wan",
+                        "wan_networkgroup": "WAN",
+                        "wan_type_v6": "dhcpv6",
+                        "ipv6_wan_delegation_type": "pd",
+                    },
+                ]
+            },
+        )
+    )
+    put_route = respx.put(f"{BASE}/rest/networkconf/lan1").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": [{"_id": "lan1", "ipv6_interface_type": "pd"}]},
+        )
+    )
+    result = await _call(
+        real_server,
+        "set_lan_ipv6",
+        {"network_id": "lan1", "interface_type": "pd", "prefix_id": "1"},
+    )
+    assert result["updated"] is True
+    import json as _json
+
+    body = _json.loads(put_route.calls[0].request.content)
+    assert body == {
+        "ipv6_interface_type": "pd",
+        "ipv6_pd_interface": "wan",
+        "ipv6_pd_prefixid": "1",
+    }
+
+
+@respx.mock
+async def test_real_set_lan_ipv6_pd_no_wan_delegation_errors(real_server: FastMCP) -> None:
+    """When no WAN has DHCPv6-PD enabled, enabling PD on a LAN returns a clear
+    error instead of letting the controller reject it with a 400."""
+    respx.get(f"{BASE}/rest/networkconf").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "_id": "lan1",
+                        "name": "Default",
+                        "purpose": "corporate",
+                        "ipv6_interface_type": "none",
+                    },
+                    {
+                        "_id": "wan1",
+                        "name": "Internet 1",
+                        "purpose": "wan",
+                        "wan_networkgroup": "WAN",
+                        "wan_type_v6": "disabled",
+                        "ipv6_wan_delegation_type": "none",
+                    },
+                ]
+            },
+        )
+    )
+    put_route = respx.put(f"{BASE}/rest/networkconf/lan1").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+    result = await _call(
+        real_server,
+        "set_lan_ipv6",
+        {"network_id": "lan1", "interface_type": "pd"},
+    )
+    assert "error" in result
+    assert "delegation" in result["error"].lower()
+    # Nothing was written.
+    assert not put_route.called
 
 
 @respx.mock


### PR DESCRIPTION
## Problem

`set_lan_ipv6(interface_type="pd")` 400'd on every live apply against the UCG-Fiber (UniFi Network 10.4.57):

```
HTTP 400 api.err.PdRequiresAssignedDhcpv6Wan
```

`dry_run` previewed clean because it didn't model the constraint. WAN1 IPv6 (DHCPv6 + PD, /56) was already fine; the gap was the LAN write payload.

## Root cause (probed live 2026-06-14)

A PD-enabled LAN networkconf must reference WHICH DHCPv6 WAN's delegation it draws from via `ipv6_pd_interface` (the WAN's networkgroup, lowercased -> `"wan"`). The tool emitted only `ipv6_interface_type="pd"` and omitted the binding.

Direct probe against the live controller:
- `{ipv6_interface_type: "pd", ipv6_pd_prefixid: "0"}` -> **HTTP 400 PdRequiresAssignedDhcpv6Wan**
- `{ipv6_interface_type: "pd", ipv6_pd_interface: "wan", ipv6_pd_prefixid: "0"}` -> **HTTP 200**

`ipv6_pd_prefixid` is accepted but **not persisted** on this firmware (the controller auto-carves the sub-prefix; it picked `4ad`).

## Fix

- When `interface_type="pd"`, auto-resolve the binding from the WAN that actually has DHCPv6-PD enabled (`ipv6_wan_delegation_type=="pd"` + non-disabled `wan_type_v6`) and inject `ipv6_pd_interface`.
- New optional `prefix_id` param -> `ipv6_pd_prefixid` (forward/cross-firmware compat; ignored by 10.4.57).
- No WAN delegating a prefix -> a clear error pointing at `set_wan_ipv6`, instead of letting the controller 400.
- Strict read-modify-write for non-IPv6 keys and the `none`/`static` paths unchanged.

## Live verification (mandatory)

Enabled the Default/MGMT LAN end-to-end through the fixed code path:
- Controller returned **HTTP 200**.
- Gateway carved `2606:380:2000:4ad::/64` from the delegated `2606:380:2000::/56` (gateway LAN addr `2606:380:2000:4ad::1`).
- Client `jump-point-nix1` picked up the global address `2606:380:2000:4ad:a6bb:6dff:feac:287c`.
- **Default IPv6 left ENABLED.** TRUSTED/IoT/GUEST is Apoc's follow-up.

## Tests / quality

- Stub + real-mode regression tests pin: the WAN-binding payload, `prefix_id` forwarding, and the no-delegation error.
- Suite **872 passed**, ruff + mypy --strict clean, tool manifest regenerated.
- Version 0.15.1 -> 0.15.2 (pyproject, `__init__`, CHANGELOG, compose pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)