### PR TITLE
5xx read-retry + maxLength param bounds (issue #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **5xx retry with exponential backoff on idempotent reads.** The three service
+  clients (`UniFiClient`, `ProtectClient`, `AccessClient`) now retry a `GET` that
+  comes back `5xx` (e.g. the `503` a gateway returns under load or mid firmware
+  upgrade) up to two extra times with exponential backoff (0.25s, 0.50s). The
+  retry policy lives in one place (`mcp_unifi/clients/retry.py`) and is shared by
+  every client HTTP helper. **Writes are never retried on a 5xx:** only `GET` is
+  eligible, because the server drives changes through a dry-run/confirm/rollback
+  model and a replayed `POST`/`PUT`/`DELETE` could double-apply. The existing
+  single retry on a connection blip (`ConnectError`/`RemoteProtocolError`) is
+  preserved unchanged.
+- **`maxLength` bounds on free-text and secret tool parameters.** Reusable
+  length-bounded `Annotated[str, Field(max_length=...)]` types
+  (`mcp_unifi/modules/_params.py`) are applied to 30 free-text/secret params
+  across the network tools (names 128, SSID 32, passphrases/passwords 128,
+  hostnames/DNS 253, free text 256, YAML spec 200 000, backup JSON 5 000 000),
+  publishing a `maxLength` constraint in each tool's input schema. This bounds
+  what reaches the UniFi controller (an unbounded name would otherwise be
+  forwarded verbatim). Identifier-style params (`*_id`, `mac`, `controller`) are
+  intentionally left unbounded — they are structurally validated downstream.
+
 ## [0.15.4] - 2026-06-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-06
+
 ### Added
 
 - **5xx retry with exponential backoff on idempotent reads.** The three service

--- a/docs/site/src/data/tool-manifest.json
+++ b/docs/site/src/data/tool-manifest.json
@@ -38,6 +38,7 @@
           },
           "spec_yaml": {
             "description": "The spec document, as a YAML string.",
+            "maxLength": 200000,
             "type": "string"
           }
         },
@@ -144,6 +145,7 @@
           },
           "host_name": {
             "description": "The FQDN to keep pointed at the WAN IP\n(``\"home.example.com\"``).",
+            "maxLength": 253,
             "type": "string"
           },
           "interface": {
@@ -153,15 +155,18 @@
           },
           "login": {
             "description": "Provider account / username. For some providers (e.g.\nNamecheap) this is the zone/domain.",
+            "maxLength": 256,
             "type": "string"
           },
           "password": {
             "description": "Provider password or API token. Stored write-only and\nredacted in reads.",
+            "maxLength": 128,
             "type": "string"
           },
           "server": {
             "default": "",
             "description": "Custom update-URL host. Only used (and required) when\n``service == \"custom\"``; leave empty otherwise.",
+            "maxLength": 253,
             "type": "string"
           },
           "service": {
@@ -207,6 +212,7 @@
           },
           "name": {
             "description": "Display name for the group (e.g. ``\"IoT Subnets\"``).",
+            "maxLength": 128,
             "type": "string"
           }
         },
@@ -265,6 +271,7 @@
           },
           "name": {
             "description": "Display name for the rule (e.g. ``\"Block iot to LAN\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "protocol": {
@@ -338,19 +345,23 @@
           },
           "name": {
             "description": "Display name for the network record (e.g. ``\"guest\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "passphrase": {
             "description": "WPA2 PSK (8-63 chars).",
+            "maxLength": 128,
             "type": "string"
           },
           "schedule": {
             "default": "",
             "description": "Optional schedule descriptor (controller field\n``schedule``). Empty = always on.",
+            "maxLength": 256,
             "type": "string"
           },
           "ssid": {
             "description": "SSID to broadcast (e.g. ``\"guest-wifi\"``).",
+            "maxLength": 32,
             "type": "string"
           },
           "subnet": {
@@ -437,10 +448,12 @@
           },
           "name": {
             "description": "Used for both the network name and the SSID (e.g. ``\"iot\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "passphrase": {
             "description": "WPA2 PSK for the IoT SSID (8-63 chars).",
+            "maxLength": 128,
             "type": "string"
           },
           "subnet": {
@@ -501,6 +514,7 @@
           },
           "name": {
             "description": "Display name for the rule.",
+            "maxLength": 128,
             "type": "string"
           },
           "proto": {
@@ -546,6 +560,7 @@
           },
           "name": {
             "description": "Display name for the profile (e.g. ``\"iot-trunk\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "native_networkconf_id": {
@@ -612,6 +627,7 @@
           },
           "name": {
             "description": "Display name for the route (e.g. ``\"Lab via firewall\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "next_hop": {
@@ -646,6 +662,7 @@
           "hostname": {
             "default": "",
             "description": "DHCP hostname (optional).",
+            "maxLength": 253,
             "type": "string"
           },
           "ip": {
@@ -659,6 +676,7 @@
           "name": {
             "default": "",
             "description": "Friendly display name (optional).",
+            "maxLength": 128,
             "type": "string"
           },
           "network_id": {
@@ -730,11 +748,13 @@
           },
           "name": {
             "description": "Network display name (e.g. ``\"iot\"``, ``\"cameras\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "purpose": {
             "default": "corporate",
             "description": "``\"corporate\"`` for normal LANs, ``\"guest\"`` for\nhotspot-style isolation.",
+            "maxLength": 128,
             "type": "string"
           },
           "subnet": {
@@ -802,6 +822,7 @@
           },
           "name": {
             "description": "SSID broadcast name (e.g. ``\"iot\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "network_id": {
@@ -810,6 +831,7 @@
           },
           "passphrase": {
             "description": "WPA pre-shared key (8-63 chars). Required unless\n``security=\"open\"``.",
+            "maxLength": 128,
             "type": "string"
           },
           "security": {
@@ -1486,6 +1508,7 @@
           "name": {
             "default": "",
             "description": "Network display name (case-insensitive) as an alternative to\n``network_id``. Errors if more than one network matches.",
+            "maxLength": 128,
             "type": "string"
           },
           "network_id": {
@@ -2444,6 +2467,7 @@
           },
           "name": {
             "description": "Display name (used for both the lease and the firewall\nrule, e.g. ``\"plex\"``).",
+            "maxLength": 128,
             "type": "string"
           },
           "network_id": {
@@ -2503,6 +2527,7 @@
           "reason": {
             "default": "",
             "description": "Free-form justification (kept in logs only,\ne.g. ``\"suspected malware c2\"``).",
+            "maxLength": 256,
             "type": "string"
           }
         },
@@ -2561,6 +2586,7 @@
           },
           "name": {
             "description": "New display name. Must be non-empty.",
+            "maxLength": 128,
             "type": "string"
           }
         },
@@ -2606,6 +2632,7 @@
         "properties": {
           "backup_json": {
             "description": "The envelope JSON string from ``backup_config``.",
+            "maxLength": 5000000,
             "type": "string"
           },
           "controller": {
@@ -3331,6 +3358,7 @@
           "name": {
             "default": "",
             "description": "New display name. Empty (default) keeps the current name.",
+            "maxLength": 128,
             "type": "string"
           }
         },
@@ -3495,6 +3523,7 @@
           "local_dns_record": {
             "default": "",
             "description": "Local DNS name to resolve to ``fixed_ip``\n(optional). When set, ``local_dns_record_enabled=true`` is\nalso sent.",
+            "maxLength": 253,
             "type": "string"
           },
           "mac": {
@@ -3504,6 +3533,7 @@
           "name": {
             "default": "",
             "description": "Friendly display name / hostname alias (optional).",
+            "maxLength": 128,
             "type": "string"
           },
           "network_id": {

--- a/src/mcp_unifi/clients/access.py
+++ b/src/mcp_unifi/clients/access.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import httpx
 
+from mcp_unifi.clients.retry import request_with_retry
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.models import UniFiRecord
 
@@ -84,31 +85,22 @@ class AccessClient:
         share one exception class with the Network and Protect clients.
         """
         url = f"{self._base}{path}"
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            try:
-                resp = await self._client.request(method, url, json=json)
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
-                last_exc = exc
-                if attempt == 0:
-                    logger.warning(
-                        "Access connection error, retrying once",
-                        extra={"method": method, "path": path, "error": str(exc)},
-                    )
-                    continue
-                raise UniFiError(f"Access connection failed: {exc}") from exc
-            except httpx.HTTPError as exc:
-                raise UniFiError(f"Access transport error: {exc}") from exc
-
-            if resp.status_code >= 400:
-                raise UniFiError(
-                    f"Access {method} {path} returned {resp.status_code}: {resp.text[:300]}"
-                )
-            if not resp.content:
-                return None
-            return resp.json()
-
-        raise UniFiError(f"Access request exhausted retries: {last_exc}")  # pragma: no cover
+        resp = await request_with_retry(
+            self._client,
+            method,
+            url,
+            logger=logger,
+            service="Access",
+            error_cls=UniFiError,
+            json=json,
+        )
+        if resp.status_code >= 400:
+            raise UniFiError(
+                f"Access {method} {path} returned {resp.status_code}: {resp.text[:300]}"
+            )
+        if not resp.content:
+            return None
+        return resp.json()
 
     @staticmethod
     def _ensure_record(result: Any) -> UniFiRecord:

--- a/src/mcp_unifi/clients/protect.py
+++ b/src/mcp_unifi/clients/protect.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import httpx
 
+from mcp_unifi.clients.retry import request_with_retry
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.models import UniFiRecord
 
@@ -83,32 +84,22 @@ class ProtectClient:
         one exception class with the Network client.
         """
         url = f"{self._base}{path}"
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            try:
-                resp = await self._client.request(method, url, json=json)
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
-                last_exc = exc
-                if attempt == 0:
-                    logger.warning(
-                        "Protect connection error, retrying once",
-                        extra={"method": method, "path": path, "error": str(exc)},
-                    )
-                    continue
-                raise UniFiError(f"Protect connection failed: {exc}") from exc
-            except httpx.HTTPError as exc:
-                raise UniFiError(f"Protect transport error: {exc}") from exc
-
-            if resp.status_code >= 400:
-                raise UniFiError(
-                    f"Protect {method} {path} returned {resp.status_code}: {resp.text[:300]}"
-                )
-            if not resp.content:
-                return None
-            return resp.json()
-
-        # Defensive — the loop above should always return or raise.
-        raise UniFiError(f"Protect request exhausted retries: {last_exc}")  # pragma: no cover
+        resp = await request_with_retry(
+            self._client,
+            method,
+            url,
+            logger=logger,
+            service="Protect",
+            error_cls=UniFiError,
+            json=json,
+        )
+        if resp.status_code >= 400:
+            raise UniFiError(
+                f"Protect {method} {path} returned {resp.status_code}: {resp.text[:300]}"
+            )
+        if not resp.content:
+            return None
+        return resp.json()
 
     async def _request_bytes(self, method: str, path: str) -> bytes:
         """Issue a binary-returning request (snapshots, thumbnails) with one retry.
@@ -116,29 +107,19 @@ class ProtectClient:
         Same retry shape as :meth:`_request` but does not call ``resp.json``.
         """
         url = f"{self._base}{path}"
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            try:
-                resp = await self._client.request(method, url)
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
-                last_exc = exc
-                if attempt == 0:
-                    logger.warning(
-                        "Protect connection error (bytes), retrying once",
-                        extra={"method": method, "path": path, "error": str(exc)},
-                    )
-                    continue
-                raise UniFiError(f"Protect connection failed: {exc}") from exc
-            except httpx.HTTPError as exc:
-                raise UniFiError(f"Protect transport error: {exc}") from exc
-
-            if resp.status_code >= 400:
-                raise UniFiError(
-                    f"Protect {method} {path} returned {resp.status_code}: {resp.text[:300]}"
-                )
-            return resp.content
-
-        raise UniFiError(f"Protect bytes request exhausted retries: {last_exc}")  # pragma: no cover
+        resp = await request_with_retry(
+            self._client,
+            method,
+            url,
+            logger=logger,
+            service="Protect",
+            error_cls=UniFiError,
+        )
+        if resp.status_code >= 400:
+            raise UniFiError(
+                f"Protect {method} {path} returned {resp.status_code}: {resp.text[:300]}"
+            )
+        return resp.content
 
     @staticmethod
     def _ensure_record(result: Any) -> UniFiRecord:

--- a/src/mcp_unifi/clients/retry.py
+++ b/src/mcp_unifi/clients/retry.py
@@ -1,0 +1,124 @@
+"""Shared HTTP retry policy for the UniFi service clients.
+
+Two transient-failure retries are layered here, both intentionally narrow:
+
+1. **Connection blips** (``ConnectError`` / ``RemoteProtocolError``) are retried
+   exactly once, preserving the original single-retry behaviour of every client.
+
+2. **5xx responses on idempotent GET reads** are retried with exponential
+   backoff (a couple of attempts). This covers the transient ``503`` a UniFi
+   gateway hands back under load or during a firmware upgrade.
+
+Writes and mutations are **never** retried on a 5xx. The server drives every
+change through a dry-run/confirm/rollback model, and a blindly retried
+``POST``/``PUT``/``DELETE`` could double-apply. Only ``GET`` — the idempotent
+read verb — is eligible for the 5xx retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+# The only HTTP method whose 5xx responses are safe to replay: an idempotent
+# read. Writes go through the dry-run/confirm/rollback path and are never
+# retried on 5xx.
+_RETRYABLE_5XX_METHOD = "GET"
+
+# Extra GET attempts after the first on a 5xx (so total attempts = 1 + this).
+MAX_5XX_RETRIES = 2
+
+# Exponential backoff base, in seconds. The sleep before retry ``n`` (0-indexed)
+# is ``BACKOFF_BASE_SECONDS * 2 ** n`` → 0.25s then 0.50s with the default base.
+# Exposed as a module attribute so the test suite can monkeypatch it to 0 and
+# keep 5xx-path tests fast.
+BACKOFF_BASE_SECONDS = 0.25
+
+
+def _is_retryable_5xx(method: str, status_code: int) -> bool:
+    """True only for a 5xx on an idempotent GET read."""
+    return method.upper() == _RETRYABLE_5XX_METHOD and 500 <= status_code < 600
+
+
+async def request_with_retry(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    logger: logging.Logger,
+    service: str,
+    error_cls: type[Exception],
+    json: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Issue an HTTP request, retrying only transient, safe-to-repeat failures.
+
+    Retries applied:
+      * One retry on ``ConnectError`` / ``RemoteProtocolError`` (network blip),
+        matching every client's original single-retry behaviour.
+      * Up to :data:`MAX_5XX_RETRIES` extra attempts on a 5xx response, but ONLY
+        for idempotent ``GET`` requests, with exponential backoff. Non-GET verbs
+        return their 5xx response immediately (the caller raises) so a write is
+        never replayed.
+
+    Returns the final :class:`httpx.Response` unconditionally on any status; the
+    caller owns turning a ``>= 400`` status into ``error_cls`` so route-specific
+    messages and 404-tolerant handling stay at the call site. ``error_cls`` is
+    raised here only when the connection retry is exhausted or a non-connection
+    transport error occurs.
+
+    Args:
+        client: Shared async httpx client (carries auth headers + pooling).
+        method: HTTP verb. Only ``GET`` is eligible for the 5xx retry.
+        url: Fully-qualified request URL.
+        logger: Client logger used for retry warnings.
+        service: Human label for log/error messages ("UniFi", "Protect", ...).
+        error_cls: Exception type raised on transport failure (e.g. ``UniFiError``).
+        json: Optional JSON body for write verbs.
+
+    Example:
+        resp = await request_with_retry(
+            self._client, "GET", url,
+            logger=logger, service="UniFi", error_cls=UniFiError,
+        )
+    """
+    connect_retried = False
+    fivexx_attempt = 0
+    while True:
+        try:
+            resp = await client.request(method, url, json=json)
+        except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
+            if not connect_retried:
+                connect_retried = True
+                logger.warning(
+                    "%s connection error, retrying once",
+                    service,
+                    extra={"method": method, "url": url, "error": str(exc)},
+                )
+                continue
+            raise error_cls(f"{service} connection failed: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise error_cls(f"{service} transport error: {exc}") from exc
+
+        if _is_retryable_5xx(method, resp.status_code) and fivexx_attempt < MAX_5XX_RETRIES:
+            delay = BACKOFF_BASE_SECONDS * (2**fivexx_attempt)
+            logger.warning(
+                "%s %s returned %s; retrying idempotent read in %.2fs (attempt %d of %d)",
+                service,
+                method,
+                resp.status_code,
+                delay,
+                fivexx_attempt + 1,
+                MAX_5XX_RETRIES,
+                extra={"url": url, "status": resp.status_code},
+            )
+            fivexx_attempt += 1
+            await asyncio.sleep(delay)
+            continue
+
+        return resp
+
+
+__all__ = ["BACKOFF_BASE_SECONDS", "MAX_5XX_RETRIES", "request_with_retry"]

--- a/src/mcp_unifi/clients/unifi.py
+++ b/src/mcp_unifi/clients/unifi.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import httpx
 
+from mcp_unifi.clients.retry import request_with_retry
 from mcp_unifi.models import UniFiRecord
 
 logger = logging.getLogger("mcp_unifi.client")
@@ -76,36 +77,26 @@ class UniFiClient:
         json: dict[str, Any] | None = None,
     ) -> Any:
         url = f"{self._base}{path}"
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            try:
-                resp = await self._client.request(method, url, json=json)
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
-                last_exc = exc
-                if attempt == 0:
-                    logger.warning(
-                        "UniFi connection error, retrying once",
-                        extra={"method": method, "path": path, "error": str(exc)},
-                    )
-                    continue
-                raise UniFiError(f"UniFi connection failed: {exc}") from exc
-            except httpx.HTTPError as exc:
-                raise UniFiError(f"UniFi transport error: {exc}") from exc
-
-            if resp.status_code >= 400:
-                raise UniFiError(
-                    f"UniFi {method} {path} returned {resp.status_code}: {resp.text[:300]}"
-                )
-            if not resp.content:
-                return None
-            body = resp.json()
-            # Legacy UniFi controller wraps payloads in {"meta": {...}, "data": [...]}.
-            if isinstance(body, dict) and "data" in body:
-                return body["data"]
-            return body
-
-        # Defensive — the loop above should always return or raise.
-        raise UniFiError(f"UniFi request exhausted retries: {last_exc}")  # pragma: no cover
+        resp = await request_with_retry(
+            self._client,
+            method,
+            url,
+            logger=logger,
+            service="UniFi",
+            error_cls=UniFiError,
+            json=json,
+        )
+        if resp.status_code >= 400:
+            raise UniFiError(
+                f"UniFi {method} {path} returned {resp.status_code}: {resp.text[:300]}"
+            )
+        if not resp.content:
+            return None
+        body = resp.json()
+        # Legacy UniFi controller wraps payloads in {"meta": {...}, "data": [...]}.
+        if isinstance(body, dict) and "data" in body:
+            return body["data"]
+        return body
 
     async def _v2_request(
         self,
@@ -127,33 +118,22 @@ class UniFiClient:
         body unchanged (list or dict), or ``None`` on an empty response.
         """
         url = f"{self._base}/v2/api/site/{self.site}{path}"
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            try:
-                resp = await self._client.request(method, url, json=json)
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
-                last_exc = exc
-                if attempt == 0:
-                    logger.warning(
-                        "UniFi v2 connection error, retrying once",
-                        extra={"method": method, "path": path, "error": str(exc)},
-                    )
-                    continue
-                raise UniFiError(f"UniFi connection failed: {exc}") from exc
-            except httpx.HTTPError as exc:
-                raise UniFiError(f"UniFi transport error: {exc}") from exc
-
-            if resp.status_code >= 400:
-                raise UniFiError(
-                    f"UniFi {method} (v2) {path} returned {resp.status_code}: {resp.text[:300]}"
-                )
-            if not resp.content:
-                return None
-            return resp.json()
-
-        raise UniFiError(  # pragma: no cover
-            f"UniFi v2 request exhausted retries: {last_exc}"
+        resp = await request_with_retry(
+            self._client,
+            method,
+            url,
+            logger=logger,
+            service="UniFi v2",
+            error_cls=UniFiError,
+            json=json,
         )
+        if resp.status_code >= 400:
+            raise UniFiError(
+                f"UniFi {method} (v2) {path} returned {resp.status_code}: {resp.text[:300]}"
+            )
+        if not resp.content:
+            return None
+        return resp.json()
 
     async def _get(self, path: str) -> Any:
         return await self._request("GET", f"{self._site_path}{path}")
@@ -262,39 +242,25 @@ class UniFiClient:
         the URL manually.
         """
         url = f"{self._base}/v2/api/site/{self.site}/apgroups"
-        last_exc: Exception | None = None
-        for attempt in range(2):
-            try:
-                resp = await self._client.request("GET", url)
-            except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
-                last_exc = exc
-                if attempt == 0:
-                    logger.warning(
-                        "UniFi connection error, retrying once",
-                        extra={"method": "GET", "path": "/v2/.../apgroups", "error": str(exc)},
-                    )
-                    continue
-                raise UniFiError(f"UniFi connection failed: {exc}") from exc
-            except httpx.HTTPError as exc:
-                raise UniFiError(f"UniFi transport error: {exc}") from exc
-
-            if resp.status_code >= 400:
-                raise UniFiError(
-                    f"UniFi GET apgroups returned {resp.status_code}: {resp.text[:300]}"
-                )
-            if not resp.content:
-                return []
-            body = resp.json()
-            # v2 endpoint returns a bare list (not the legacy meta+data envelope).
-            if isinstance(body, list):
-                return body
-            if isinstance(body, dict) and "data" in body:
-                return body["data"] if isinstance(body["data"], list) else []
-            return []
-
-        raise UniFiError(  # pragma: no cover
-            f"UniFi apgroups request exhausted retries: {last_exc}"
+        resp = await request_with_retry(
+            self._client,
+            "GET",
+            url,
+            logger=logger,
+            service="UniFi",
+            error_cls=UniFiError,
         )
+        if resp.status_code >= 400:
+            raise UniFiError(f"UniFi GET apgroups returned {resp.status_code}: {resp.text[:300]}")
+        if not resp.content:
+            return []
+        body = resp.json()
+        # v2 endpoint returns a bare list (not the legacy meta+data envelope).
+        if isinstance(body, list):
+            return body
+        if isinstance(body, dict) and "data" in body:
+            return body["data"] if isinstance(body["data"], list) else []
+        return []
 
     async def list_clients(self) -> list[UniFiRecord]:
         """Return currently active wireless and wired clients on the gateway.

--- a/src/mcp_unifi/modules/_params.py
+++ b/src/mcp_unifi/modules/_params.py
@@ -1,0 +1,56 @@
+"""Reusable length-bounded string parameter types for tool signatures.
+
+FastMCP derives each tool's JSON input schema from its function signature, so
+annotating a parameter as ``Annotated[str, Field(max_length=N)]`` publishes a
+``maxLength`` constraint in the tool's input schema. That bounds free-text and
+secret inputs before they reach the UniFi controller: an unbounded ``name`` or
+``passphrase`` would otherwise be forwarded verbatim, and a multi-kilobyte
+value could trigger upstream truncation or errors. The docstring-derived
+parameter description is preserved alongside the constraint.
+
+Bounds are deliberately generous (they only reject clearly-junk oversized
+input), so they never break a legitimate call. Identifier-style params
+(``*_id``, ``mac``, ``controller``) are intentionally not bounded here: they are
+structurally validated downstream (registry lookup, path resolution) and are not
+free text stored on the controller.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+# Short human labels stored on the controller (network/WLAN/rule/profile names,
+# network purpose). Generous cap well above any real UniFi name length.
+BoundedName = Annotated[str, Field(max_length=128)]
+
+# WLAN SSID. 802.11 caps the SSID element at 32 octets.
+BoundedSsid = Annotated[str, Field(max_length=32)]
+
+# Secrets: WPA passphrases, Dynamic DNS passwords. WPA2-PSK maxes at 63 chars;
+# the headroom covers WPA3/enterprise-style longer secrets.
+BoundedSecret = Annotated[str, Field(max_length=128)]
+
+# Hostnames, FQDNs, DNS records, and provider update URLs. DNS names cap at 253.
+BoundedHostname = Annotated[str, Field(max_length=253)]
+
+# General short free text (reasons, provider logins, schedule expressions).
+BoundedText = Annotated[str, Field(max_length=256)]
+
+# A declared desired-state YAML spec passed to the drift auditor. Large by
+# design, but still bounded so a runaway blob is rejected at the schema.
+BoundedYaml = Annotated[str, Field(max_length=200_000)]
+
+# A full config-backup JSON blob passed to the restore tool. Bounded high.
+BoundedJson = Annotated[str, Field(max_length=5_000_000)]
+
+__all__ = [
+    "BoundedHostname",
+    "BoundedJson",
+    "BoundedName",
+    "BoundedSecret",
+    "BoundedSsid",
+    "BoundedText",
+    "BoundedYaml",
+]

--- a/src/mcp_unifi/modules/network/backup.py
+++ b/src/mcp_unifi/modules/network/backup.py
@@ -84,6 +84,9 @@ from mcp_unifi.backends import Backend
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedJson,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 
 if TYPE_CHECKING:
@@ -422,7 +425,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("restore_config")
     async def restore_config(
-        backup_json: str,
+        backup_json: BoundedJson,
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:

--- a/src/mcp_unifi/modules/network/composites.py
+++ b/src/mcp_unifi/modules/network/composites.py
@@ -16,6 +16,12 @@ from mcp_unifi.backends import Backend
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+    BoundedSecret,
+    BoundedSsid,
+    BoundedText,
+)
 from mcp_unifi.modules.network._common import (
     format_json,
     make_err,
@@ -71,9 +77,9 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_iot_network")
     async def create_iot_network(
-        name: str,
+        name: BoundedName,
         vlan_id: int,
-        passphrase: str,
+        passphrase: BoundedSecret,
         main_lan_subnet: str = "192.168.1.0/24",
         subnet: str = "",
         isolate: bool = True,
@@ -273,7 +279,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("provision_homelab_service")
     async def provision_homelab_service(
-        name: str,
+        name: BoundedName,
         mac: str,
         ip: str,
         network_id: str,
@@ -446,7 +452,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @audited("quarantine_client")
     async def quarantine_client(
         mac: str,
-        reason: str = "",
+        reason: BoundedText = "",
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:
@@ -505,13 +511,13 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_guest_network")
     async def create_guest_network(
-        name: str,
-        ssid: str,
-        passphrase: str,
+        name: BoundedName,
+        ssid: BoundedSsid,
+        passphrase: BoundedSecret,
         vlan_id: int,
         main_lan_subnet: str = "192.168.1.0/24",
         subnet: str = "",
-        schedule: str = "",
+        schedule: BoundedText = "",
         hide_ssid: bool = False,
         controller: str = "default",
         dry_run: bool = False,

--- a/src/mcp_unifi/modules/network/devices.py
+++ b/src/mcp_unifi/modules/network/devices.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 
 if TYPE_CHECKING:
@@ -584,7 +587,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @audited("rename_device")
     async def rename_device(
         device_mac: str,
-        name: str,
+        name: BoundedName,
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:

--- a/src/mcp_unifi/modules/network/dhcp.py
+++ b/src/mcp_unifi/modules/network/dhcp.py
@@ -8,6 +8,10 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedHostname,
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
 
@@ -53,8 +57,8 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         mac: str,
         ip: str,
         network_id: str,
-        name: str = "",
-        hostname: str = "",
+        name: BoundedName = "",
+        hostname: BoundedHostname = "",
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:
@@ -114,8 +118,8 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         mac: str,
         fixed_ip: str,
         network_id: str,
-        name: str = "",
-        local_dns_record: str = "",
+        name: BoundedName = "",
+        local_dns_record: BoundedHostname = "",
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:

--- a/src/mcp_unifi/modules/network/drift.py
+++ b/src/mcp_unifi/modules/network/drift.py
@@ -59,6 +59,9 @@ import yaml
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedYaml,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 
 if TYPE_CHECKING:
@@ -404,7 +407,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("audit_network_drift")
     async def audit_network_drift(
-        spec_yaml: str,
+        spec_yaml: BoundedYaml,
         controller: str = "default",
     ) -> str:
         """Compare current controller state to a declared YAML spec.

--- a/src/mcp_unifi/modules/network/dynamic_dns.py
+++ b/src/mcp_unifi/modules/network/dynamic_dns.py
@@ -26,6 +26,11 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedHostname,
+    BoundedSecret,
+    BoundedText,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
 
@@ -107,10 +112,10 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @audited("create_dynamic_dns")
     async def create_dynamic_dns(
         service: str,
-        host_name: str,
-        login: str,
-        password: str,
-        server: str = "",
+        host_name: BoundedHostname,
+        login: BoundedText,
+        password: BoundedSecret,
+        server: BoundedHostname = "",
         interface: str = "wan",
         enabled: bool = True,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/firewall.py
+++ b/src/mcp_unifi/modules/network/firewall.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
 
@@ -55,7 +58,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_firewall_rule")
     async def create_firewall_rule(
-        name: str,
+        name: BoundedName,
         ruleset: str,
         action: str,
         rule_index: int = 20000,
@@ -355,7 +358,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_firewall_group")
     async def create_firewall_group(
-        name: str,
+        name: BoundedName,
         group_type: str,
         members: list[str],
         controller: str = "default",
@@ -416,7 +419,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @audited("update_firewall_group")
     async def update_firewall_group(
         group_id: str,
-        name: str = "",
+        name: BoundedName = "",
         members: list[str] | None = None,
         controller: str = "default",
         dry_run: bool = False,

--- a/src/mcp_unifi/modules/network/port_forwards.py
+++ b/src/mcp_unifi/modules/network/port_forwards.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
 
@@ -49,7 +52,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_port_forward")
     async def create_port_forward(
-        name: str,
+        name: BoundedName,
         fwd: str,
         fwd_port: str,
         dst_port: str,

--- a/src/mcp_unifi/modules/network/port_profiles.py
+++ b/src/mcp_unifi/modules/network/port_profiles.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
 
@@ -51,7 +54,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_port_profile")
     async def create_port_profile(
-        name: str,
+        name: BoundedName,
         native_networkconf_id: str = "",
         forward: str = "all",
         poe_mode: str = "auto",

--- a/src/mcp_unifi/modules/network/routing.py
+++ b/src/mcp_unifi/modules/network/routing.py
@@ -26,6 +26,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import format_json, make_err
 from mcp_unifi.modules.network._pending import build_preview_envelope, get_pending_actions
 
@@ -98,7 +101,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_route")
     async def create_route(
-        name: str,
+        name: BoundedName,
         destination: str,
         next_hop: str,
         distance: int = 1,

--- a/src/mcp_unifi/modules/network/vlans.py
+++ b/src/mcp_unifi/modules/network/vlans.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+)
 from mcp_unifi.modules.network._common import (
     format_json,
     make_err,
@@ -61,7 +64,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @audited("get_network_details")
     async def get_network_details(
         network_id: str = "",
-        name: str = "",
+        name: BoundedName = "",
         controller: str = "default",
     ) -> str:
         """Show one network's full record, grouped into readable sections.
@@ -160,12 +163,12 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_vlan")
     async def create_vlan(
-        name: str,
+        name: BoundedName,
         vlan_id: int,
         subnet: str,
         dhcp_start: str = "",
         dhcp_stop: str = "",
-        purpose: str = "corporate",
+        purpose: BoundedName = "corporate",
         controller: str = "default",
         dry_run: bool = False,
     ) -> str:

--- a/src/mcp_unifi/modules/network/wlans.py
+++ b/src/mcp_unifi/modules/network/wlans.py
@@ -8,6 +8,10 @@ from typing import TYPE_CHECKING, Any
 from mcp_unifi.clients.unifi import UniFiError
 from mcp_unifi.dispatcher import resolve_backend
 from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._params import (
+    BoundedName,
+    BoundedSecret,
+)
 from mcp_unifi.modules.network._common import (
     format_json,
     make_err,
@@ -82,8 +86,8 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     @mcp.tool()
     @audited("create_wlan")
     async def create_wlan(
-        name: str,
-        passphrase: str,
+        name: BoundedName,
+        passphrase: BoundedSecret,
         network_id: str,
         security: str = "wpapsk",
         wpa_mode: str = "wpa2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,21 @@ from collections.abc import Iterator
 import pytest
 
 from mcp_unifi import audit
+from mcp_unifi.clients import retry as _retry
 from mcp_unifi.clients.stubs import StubState
 from mcp_unifi.config import Settings
 from mcp_unifi.modules.network._pending import reset_pending_actions
+
+
+@pytest.fixture(autouse=True)
+def _fast_retry_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero the 5xx-retry backoff so read-path retry tests don't sleep.
+
+    The retry helper waits ``BACKOFF_BASE_SECONDS`` between attempts on a 5xx
+    GET. In production that is a short real delay; under test it would add up
+    across the many upstream-500 cases, so we drive it to 0.
+    """
+    monkeypatch.setattr(_retry, "BACKOFF_BASE_SECONDS", 0.0)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -188,6 +188,56 @@ async def test_5xx_raises_unifi_error(client: UniFiClient) -> None:
 
 
 @respx.mock
+async def test_5xx_get_retries_then_succeeds(client: UniFiClient) -> None:
+    """A transient 503 on an idempotent GET is retried until it succeeds."""
+    route = respx.get(f"{BASE}/rest/networkconf").mock(
+        side_effect=[
+            httpx.Response(503, text="upgrading"),
+            httpx.Response(503, text="upgrading"),
+            httpx.Response(200, json={"data": [{"_id": "n1"}]}),
+        ]
+    )
+    result = await client.list_networks()
+    assert result == [{"_id": "n1"}]
+    # 1 initial + MAX_5XX_RETRIES (2) = 3 total attempts.
+    assert route.call_count == 3
+
+
+@respx.mock
+async def test_5xx_get_exhausts_retries_then_raises(client: UniFiClient) -> None:
+    """A persistent 5xx on a GET raises after the retry budget is spent."""
+    route = respx.get(f"{BASE}/rest/networkconf").mock(
+        return_value=httpx.Response(503, text="down")
+    )
+    with pytest.raises(UniFiError):
+        await client.list_networks()
+    assert route.call_count == 3
+
+
+@respx.mock
+async def test_5xx_write_is_not_retried(client: UniFiClient) -> None:
+    """A 5xx on a write (POST) must NOT be retried — a retried write could
+    double-apply under the dry-run/confirm/rollback model."""
+    route = respx.post(f"{BASE}/rest/networkconf").mock(
+        return_value=httpx.Response(503, text="down")
+    )
+    with pytest.raises(UniFiError):
+        await client.create_network({"name": "x"})
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_5xx_put_is_not_retried(client: UniFiClient) -> None:
+    """A 5xx on a PUT update is issued exactly once (no replay)."""
+    route = respx.put(f"{BASE}/rest/networkconf/n1").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    with pytest.raises(UniFiError):
+        await client.update_network("n1", {"name": "x"})
+    assert route.call_count == 1
+
+
+@respx.mock
 async def test_connection_error_retries_then_raises(client: UniFiClient) -> None:
     respx.get(f"{BASE}/stat/device").mock(side_effect=httpx.ConnectError("nope"))
     with pytest.raises(UniFiError) as exc:

--- a/tests/test_param_bounds.py
+++ b/tests/test_param_bounds.py
@@ -1,0 +1,63 @@
+"""Free-text / secret tool parameters must publish a ``maxLength`` bound.
+
+FastMCP derives each tool's JSON input schema from its signature, so annotating
+a parameter as ``Annotated[str, Field(max_length=N)]`` (see
+``mcp_unifi.modules._params``) emits ``maxLength`` in the schema. This guards
+the UniFi controller from an unbounded free-text value (e.g. a 10 KB ``name``).
+
+These tests pin the contract so a future signature edit that drops the bound is
+caught in CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_unifi.config import Settings
+from mcp_unifi.server import build_server
+
+# (tool_name, param_name) -> expected maxLength
+EXPECTED_BOUNDS: dict[tuple[str, str], int] = {
+    ("create_vlan", "name"): 128,
+    ("create_vlan", "purpose"): 128,
+    ("create_wlan", "name"): 128,
+    ("create_wlan", "passphrase"): 128,
+    ("create_guest_network", "ssid"): 32,
+    ("rename_device", "name"): 128,
+    ("create_dynamic_dns", "password"): 128,
+    ("create_dynamic_dns", "host_name"): 253,
+    ("restore_config", "backup_json"): 5_000_000,
+    ("audit_network_drift", "spec_yaml"): 200_000,
+}
+
+
+async def _tool_schemas() -> dict[str, dict]:
+    settings = Settings(
+        stub_mode=True, log_format="text", mcp_transport="stdio", auth_required=False
+    )
+    server = build_server(settings)
+    tools = await server.list_tools()
+    items = tools.values() if isinstance(tools, dict) else tools
+    return {t.name: t.parameters for t in items}
+
+
+@pytest.mark.asyncio
+async def test_free_text_params_have_maxlength() -> None:
+    schemas = await _tool_schemas()
+    for (tool_name, param), expected in EXPECTED_BOUNDS.items():
+        assert tool_name in schemas, f"tool {tool_name} not registered"
+        props = schemas[tool_name].get("properties", {})
+        assert param in props, f"{tool_name} has no param {param}"
+        actual = props[param].get("maxLength")
+        assert actual == expected, (
+            f"{tool_name}.{param} maxLength = {actual!r}, expected {expected}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_bounded_string_params_are_strings() -> None:
+    """A bounded param must still be a plain string in the schema (no type drift)."""
+    schemas = await _tool_schemas()
+    for (tool_name, param), _ in EXPECTED_BOUNDS.items():
+        prop = schemas[tool_name]["properties"][param]
+        assert prop.get("type") == "string", f"{tool_name}.{param} is not a string"


### PR DESCRIPTION
Implements the two "worth keeping" findings from the mcp-unifi audit (issue #53).

## 1. 5xx retry with exponential backoff on idempotent reads only
- New shared helper `src/mcp_unifi/clients/retry.py`, used by `UniFiClient`, `ProtectClient`, and `AccessClient`.
- A `GET` returning 5xx (e.g. the `503` a gateway throws under load or during a firmware upgrade) is retried up to 2 extra times with 0.25s/0.50s exponential backoff.
- **Writes are never retried on 5xx** — only `GET` is eligible. The server drives changes through a dry-run/confirm/rollback model, so a replayed `POST`/`PUT`/`DELETE` could double-apply.
- The existing single connection-error retry (`ConnectError`/`RemoteProtocolError`) is preserved unchanged.

## 2. maxLength bounds on free-text / secret tool parameters
- New reusable `Annotated[str, Field(max_length=...)]` types in `src/mcp_unifi/modules/_params.py`, applied to 30 free-text/secret params across the network tools (names 128, SSID 32, passphrases/passwords 128, hostnames/DNS 253, free text 256, YAML spec 200000, backup JSON 5000000).
- Publishes a `maxLength` constraint in each tool's input schema; regenerated `docs/site/src/data/tool-manifest.json`.
- Identifier params (`*_id`, `mac`, `controller`) intentionally left unbounded — structurally validated downstream.

Skipped (out of scope per the audit triage): caching, Prometheus metrics, SSE transport.

## Verification
- Full suite: **886 passed** (880 baseline + 6 new regression tests, incl. proof that 5xx writes are not retried).
- ruff lint + format clean; mypy strict clean (50 files); no new dependencies (no lockfile drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)