### PR TITLE
fix(docs): bump nanoid past CVE-2026-67213, add npm coverage for the docs site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,3 +58,24 @@ updates:
       update-types:
       - minor
       - patch
+# The docs site is a separate npm project. Without this block nothing watches
+# it, which is how nanoid CVE-2026-67213 sat open with no PR to fix it.
+- package-ecosystem: npm
+  directory: "/docs/site"
+  schedule:
+    interval: weekly
+    day: thursday
+    time: '09:30'
+    timezone: America/New_York
+  open-pull-requests-limit: 2
+  labels:
+  - dependencies
+  - javascript
+  commit-message:
+    prefix: deps(docs)
+    include: scope
+  groups:
+    npm-minor-patch:
+      update-types:
+      - minor
+      - patch

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -5339,9 +5339,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes the one open high-severity Dependabot alert on this repo.

`nanoid` 3.3.16 in `docs/site/package-lock.json` is vulnerable to CVE-2026-67213 (fix 3.3.17). Bumped to 3.3.18. It is a transitive dependency, so `package.json` is untouched and the diff is three lines in the lock.

**Why there was no Dependabot PR for it:** `.github/dependabot.yml` covers pip, docker, and github-actions, but the docs site is a separate npm project under `/docs/site` and nothing watched it. Added an `npm` ecosystem for that directory so the gap does not reopen.

Regenerated with npm 11 to match the lockfile format already committed; npm 10 silently strips the `libc` fields from optional platform deps.