### PR TITLE
fix(image): drop pip from the runtime layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,12 @@ WORKDIR /app
 COPY --from=builder /wheels /app/site-packages
 RUN chown -R mcp:mcp /app
 
+# Runtime does not use pip: the wheels above are pre-installed and the entrypoint
+# runs `python -m mcp_unifi.server`. Removing pip drops its vendored dependencies
+# (msgpack, setuptools, requests, ...), which Trivy scans as if they were
+# installed packages and flags for CVEs unreachable from this server.
+RUN pip uninstall -y pip
+
 USER mcp
 
 EXPOSE 3714


### PR DESCRIPTION
Trivy on v0.19.0 flagged two HIGH CVEs — msgpack \`GHSA-6v7p-g79w-8964\` and setuptools \`CVE-2025-47273\` — and both were vendored inside pip's \`_vendor/\` tree in the runtime image. Neither is directly installed, and the code is only reachable through pip itself.

Runtime doesn't run pip. Wheels are pre-installed by the builder stage, and the entrypoint is a bare \`python -m mcp_unifi.server\`. Dropping pip from the runtime layer removes both vulns without changing what the container actually runs.

Bumping pip wouldn't have fixed it — pip 26.2.1 is already the current release and still vendors those versions.

## Test plan
- [x] Local rebuild: no \`msgpack\` or \`setuptools\` anywhere in the image
- [x] All top-level module imports pass in the pip-less image
- [x] Healthcheck exits identically to the pip-having image (rc=1 when no server is up, same as baseline)
- [ ] CI green (Trivy should be clean on this PR)