### PR TITLE
release: 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-09
+
+### Fixed
+
+- **SECURITY (image): dropped pip from the runtime layer.** pip 26.2.1 ships
+  msgpack 1.1.2 and setuptools 70.3.0 vendored under `pip/_vendor/`, and Trivy
+  scans those as installed packages — surfacing GHSA-6v7p-g79w-8964 (msgpack
+  OOB read on Unpacker reuse) and CVE-2025-47273 (setuptools PackageIndex path
+  traversal) on the 0.19.0 image. Neither is reachable from the server, but
+  they were present. Runtime never runs pip: wheels are pre-installed into
+  `/app/site-packages` by the builder stage and the entrypoint is a bare
+  `python -m mcp_unifi.server`. Uninstalling pip removes the vendor tree
+  entirely and the image passes Trivy at HIGH/CRITICAL with zero findings.
+  Bumping pip would not have fixed it: 26.2.1 is already the current release
+  and still vendors those versions.
+
 ## [0.19.0] - 2026-08-08
 
 Two independent changes that share a premise: the server should tell the

--- a/charts/mcp-unifi/Chart.yaml
+++ b/charts/mcp-unifi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-unifi
 description: MCP server for self-hosted UniFi gateway management (Network + Protect + Access)
 type: application
-version: 0.2.2
-appVersion: "0.19.0"
+version: 0.2.3
+appVersion: "0.19.1"
 home: https://github.com/pete-builds/mcp-unifi
 sources:
   - https://github.com/pete-builds/mcp-unifi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   mcp-unifi:
-    image: ghcr.io/pete-builds/mcp-unifi:0.19.0
+    image: ghcr.io/pete-builds/mcp-unifi:0.19.1
     container_name: mcp-unifi
     restart: unless-stopped
     read_only: true

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mcp-unifi",
   "display_name": "UniFi Gateway",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "MCP server for self-hosted UniFi gateway management.",
   "long_description": "Self-hosted UniFi gateway management: VLANs, WLANs, firewall, clients, DHCP, observability, UniFi Protect cameras, and UniFi Access doors / credentials / badge events. Multi-site, dry-run on destructive ops, replayable audit log. Stub mode lets you try the full tool surface with no hardware.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.19.0"
+version = "0.19.1"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/pete-builds/mcp-unifi",
     "source": "github"
   },
-  "version": "0.19.0",
+  "version": "0.19.1",
   "websiteUrl": "https://pete-builds.github.io/mcp-unifi/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.19.0",
+      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.19.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3714/mcp"

--- a/src/mcp_unifi/__init__.py
+++ b/src/mcp_unifi/__init__.py
@@ -19,4 +19,4 @@ a real UCG-Fiber, UDM Pro, or other UniFi OS gateway.
 
 from __future__ import annotations
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"


### PR DESCRIPTION
Patch release carrying #78. Bumps every version surface plus the chart from 0.2.2 → 0.2.3. See CHANGELOG for the fix summary.

## Test plan
- [ ] CI green (Trivy should stay clean)
- [ ] Tag v0.19.1 after merge
- [ ] GHCR image ghcr.io/pete-builds/mcp-unifi:0.19.1 published
- [ ] nix1 autodeploy picks up the bump