### PR TITLE
release: 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.20.0] - 2026-08-12
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,53 @@ Stub mode is the default; you do not need a UniFi gateway to develop or run the 
 
 Use the issue templates. For bugs, include the gateway model + firmware (visible in `get_site_health` output) — most UniFi quirks are firmware-version-dependent.
 
+## Release procedure
+
+`release.yml` refers you here, so here it is.
+
+A release is cut by pushing a `v*.*.*` tag. Before that tag exists, **every
+version surface must already say the new version in a merged commit**. The
+release workflow verifies all seven and fails closed if any disagree, because
+tags v0.10.0 through v0.16.0 shipped misreporting their own version when the
+bump happened inside the runner instead.
+
+The surfaces, all bumped together:
+
+| Surface | Field |
+| --- | --- |
+| `pyproject.toml` | `version` |
+| `src/mcp_unifi/__init__.py` | `__version__` |
+| `manifest.json` | `version` |
+| `server.json` | `version` **and** `packages[0].identifier` (the `ghcr.io/…:X.Y.Z` pin) |
+| `docker-compose.yml` | the `image:` tag |
+| `charts/mcp-unifi/Chart.yaml` | `appVersion` |
+
+Plus one the workflow does *not* check: `charts/mcp-unifi/Chart.yaml`
+`version`, the chart's own semver. chart-releaser runs with
+`CR_SKIP_EXISTING: "true"`, so leaving it alone means the chart silently is
+not republished. Bump it whenever the chart or the app version changes.
+
+`CHANGELOG.md` needs a literal `## [X.Y.Z] - YYYY-MM-DD` heading. The workflow
+extracts that section verbatim as the GitHub release body and aborts if it is
+missing or empty, so rename `## [Unreleased]` rather than adding a heading
+beneath it.
+
+Steps:
+
+```bash
+git checkout -b release/X.Y.Z
+# bump the surfaces above; rename the Unreleased heading
+git commit -am "release: X.Y.Z"
+# open the PR, let CI go green, merge it
+git checkout main && git pull
+git tag vX.Y.Z && git push origin vX.Y.Z
+```
+
+The tag fans out to three workflows: `release.yml` (multi-arch build, cosign
+keyless signature, SLSA provenance, SBOM, `.dxt` bundle, GitHub release),
+`helm-release.yml`, and `publish-mcp.yml` (MCP Registry, which polls GHCR for
+up to 30 minutes waiting on the image the release build is still producing).
+
 ## Scope
 
 Currently in scope: Network module, Protect module, Access module (read-only — writes deferred until session-token auth lands), the safety substrate (dry-run, audit, rollback), and distribution. **Out of scope** for now: UniFi Drive, UniFi Talk. Open an issue if you want to discuss adding one of these as a new module.

--- a/charts/mcp-unifi/Chart.yaml
+++ b/charts/mcp-unifi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-unifi
 description: MCP server for self-hosted UniFi gateway management (Network + Protect + Access)
 type: application
-version: 0.2.3
-appVersion: "0.19.1"
+version: 0.2.4
+appVersion: "0.20.0"
 home: https://github.com/pete-builds/mcp-unifi
 sources:
   - https://github.com/pete-builds/mcp-unifi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   mcp-unifi:
-    image: ghcr.io/pete-builds/mcp-unifi:0.19.1
+    image: ghcr.io/pete-builds/mcp-unifi:0.20.0
     container_name: mcp-unifi
     restart: unless-stopped
     read_only: true

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mcp-unifi",
   "display_name": "UniFi Gateway",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "MCP server for self-hosted UniFi gateway management.",
   "long_description": "Self-hosted UniFi gateway management: VLANs, WLANs, firewall, clients, DHCP, observability, UniFi Protect cameras, and UniFi Access doors / credentials / badge events. Multi-site, dry-run on destructive ops, replayable audit log. Stub mode lets you try the full tool surface with no hardware.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.19.1"
+version = "0.20.0"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/pete-builds/mcp-unifi",
     "source": "github"
   },
-  "version": "0.19.1",
+  "version": "0.20.0",
   "websiteUrl": "https://pete-builds.github.io/mcp-unifi/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.19.1",
+      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.20.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3714/mcp"

--- a/src/mcp_unifi/__init__.py
+++ b/src/mcp_unifi/__init__.py
@@ -19,4 +19,4 @@ a real UCG-Fiber, UDM Pro, or other UniFi OS gateway.
 
 from __future__ import annotations
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"


### PR DESCRIPTION
Cuts 0.20.0, carrying the read-path and write-path redaction hardening merged in #80.

## Why minor, not patch

`restore_config` now force-disables restored **networks** that carry the redaction sentinel, matching the behavior WLANs already had. A backup taken from a controller with VPN networks will restore those networks `enabled=false` rather than round-tripping a cleartext PSK. That is a change in restore fidelity, not just in what the tools print, so it does not belong in a patch bump.

## Surfaces bumped

All seven the release guard verifies (`pyproject.toml`, `__init__.py`, `manifest.json`, `server.json` version + OCI identifier, `docker-compose.yml`, `Chart.yaml` `appVersion`), plus the chart's own `version` 0.2.3 → 0.2.4 so chart-releaser actually republishes it under `CR_SKIP_EXISTING`.

Guard and the CHANGELOG notes extraction were both run locally against this branch: all seven surfaces ok, 166 lines of release notes extracted.

## Also here

`docs(contributing)`: the release guard's failure message points at a CONTRIBUTING.md section that did not exist. Now it does, including the chart-version surface the guard does not check and cannot warn you about.