### PR TITLE
feat(security): read-only mode with explicit per-tool write classification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,16 @@ MCP_UNIFI_AUTH_TOKENS=
 # network namespace). Even then, prefer setting at least one token.
 MCP_UNIFI_AUTH_REQUIRED=true
 
+# ---------------------------------------------------------------------------
+# Read-only mode
+# ---------------------------------------------------------------------------
+# When true, every tool that changes state is hidden from tools/list AND
+# refused on tools/call; read tools are unaffected. Defense in depth on top of
+# a read-only UniFi API key: the key decides what the controller accepts, this
+# decides what the server is willing to attempt. Default false so existing
+# deployments keep their current behavior.
+MCP_UNIFI_READONLY=false
+
 TZ=UTC
 
 # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Read-only mode (`MCP_UNIFI_READONLY`).** Set it to `true` and the server
+  becomes structurally unable to change anything: every mutating tool is
+  dropped from `tools/list` *and* refused on `tools/call`. Both halves ship
+  together on purpose — hiding a tool only removes the suggestion, and a client
+  that hard-codes a name, replays a cached manifest, or guesses would still
+  reach the tool body. Refusals return the standard
+  `{"error": ..., "stub_mode": ...}` envelope rather than raising a framework
+  error, so no caller needs a second failure path. Default `false`; existing
+  deployments are unaffected. This is defense in depth on top of a read-only
+  UniFi API key, not a replacement for one.
+- **Explicit per-tool write classification.** Every tool now declares
+  `mutates=True` or `mutates=False` on its `@audited(...)` decorator, next to
+  its body and its `Side effects:` docstring. The argument is required, so a
+  tool added without it raises at import and the server refuses to start; a
+  test enumerates the live registration and fails CI on the same condition.
+  There is no default that would let a new mutating tool stay callable in
+  read-only mode.
+
+  Classification is deliberately *not* inferred from tool names. Twelve
+  mutating tools carry none of the write-shaped prefixes a name-based gate
+  would key on: `confirm_destructive_action`, `restore_config`,
+  `block_client`, `unblock_client`, `quarantine_client`, `reconnect_client`,
+  `restart_device`, `rename_device`, `locate_device`, `toggle_traffic_rule`,
+  `toggle_traffic_route`, `trigger_speedtest`. The first of those executes a
+  queued delete, so a prefix-matching gate would have shipped a "read-only"
+  server that still commits deletions.
+
+  Judgment calls are recorded in a comment beside each classification:
+  `trigger_speedtest` and `locate_device` mutate (they make the hardware do
+  work and flash a physical LED, respectively, even though no config changes);
+  `rename_device` mutates (cosmetic but persisted); `backup_config` is a read
+  (a fan-out of GETs returned to the caller, writing nothing to the
+  controller); the console tools are reads despite the login POST; and every
+  `delete_*` tool mutates including its preview phase, because
+  preview-then-confirm is an interlock against mistakes, not an access
+  control.
+
+### Changed
+
+- `register_modules` now raises `UnclassifiedToolError` when a registered tool
+  has no `mutates` declaration, when a tool exposes no tags set, or when the
+  tool list cannot be enumerated at all. Tagging used to be best-effort;
+  per-client scoping and read-only mode both depend on those tags, so a
+  silent no-op is no longer an acceptable outcome.
+
 ## [0.20.0] - 2026-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Full guides for each install path live in the [docs site](https://pete-builds.gi
 
 ## Design
 
+- **Read-only mode.** `MCP_UNIFI_READONLY=true` makes the server structurally unable to change anything: mutating tools are hidden from `tools/list` *and* refused on `tools/call`, so naming a hidden tool gets a normal error envelope instead of a write. Classification is declared per tool at registration (`@audited("list_networks", mutates=False)`), never inferred from tool names — twelve mutating tools, `confirm_destructive_action` among them, carry no `create_`/`update_`/`delete_`/`set_` prefix. Registration fails if a tool has not declared a classification, so a new tool cannot default into being callable. Defense in depth on top of a read-only UniFi API key, not a replacement for it.
 - **Safety primitives.** Every destructive tool accepts `dry_run=True` and returns the predicted change set without writing. Composite tools (`create_iot_network`, `create_guest_network`, `provision_homelab_service`, `provision_camera`) capture pre-state and roll back applied steps on partial failure. Every tool call lands in a JSONL audit log with secrets scrubbed; the included `mcp-unifi-replay` CLI can re-issue a log against a fresh controller.
 - **Single image, multi-controller.** One container runs Network, Protect, and Access together. The same process manages multiple UniFi sites in parallel via the `controller` parameter and a YAML controllers file (`MCP_UNIFI_CONTROLLERS_FILE`). No need to run a separate process per controller.
 - **API-key-first auth.** Uses the local API key from Settings → Control Plane → Integrations against the `/proxy/network/api` endpoint. No username/password storage, no cloud account, no Site Manager dependency.
@@ -119,13 +120,14 @@ Generate the API key under **Settings → Control Plane → Integrations → Cre
 
 ## Configuration
 
-All config is read from environment variables (and `.env` when present). The five most common:
+All config is read from environment variables (and `.env` when present). The six most common:
 
 | Variable | Default | Notes |
 |---|---|---|
 | `STUB_MODE` | `true` | When `false`, real-mode controller config is required. |
 | `UNIFI_HOST` | (empty) | Gateway IP or hostname. Required in real mode. |
 | `UNIFI_API_KEY` | (empty) | Local API key. Required in real mode. |
+| `MCP_UNIFI_READONLY` | `false` | When `true`, mutating tools are hidden and refused. See the [Security guide](https://pete-builds.github.io/mcp-unifi/guides/security/#read-only-mode). |
 | `MCP_UNIFI_MODULES_ENABLED` | `network` | Set to `network,protect,access` to enable all three modules. |
 | `MCP_UNIFI_CONTROLLERS_FILE` | (unset) | YAML file with named controllers for multi-site. |
 

--- a/charts/mcp-unifi/templates/deployment.yaml
+++ b/charts/mcp-unifi/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ .Values.modulesEnabled | quote }}
             - name: MCP_UNIFI_AUTH_REQUIRED
               value: {{ .Values.auth.required | quote }}
+            - name: MCP_UNIFI_READONLY
+              value: {{ .Values.readOnly | quote }}
             {{- if or .Values.existingSecret .Values.unifi.apiKey }}
             - name: UNIFI_API_KEY
               valueFrom:

--- a/charts/mcp-unifi/values.yaml
+++ b/charts/mcp-unifi/values.yaml
@@ -27,6 +27,12 @@ existingSecret: ""
 
 modulesEnabled: "network"
 
+# Read-only mode (v0.21.0+). When true, every tool that changes state is
+# hidden from tools/list and refused on tools/call; read tools are unaffected.
+# Defense in depth on top of a read-only UniFi API key — pair the two rather
+# than picking one.
+readOnly: false
+
 # HTTP transport authentication (v0.9.0+).
 # `tokens` is a comma-separated list of bearer tokens. Each entry is either a
 # bare token (auto-assigned client_id `client-N`) or a `name:token` pair.

--- a/docs/site/src/content/docs/guides/security.md
+++ b/docs/site/src/content/docs/guides/security.md
@@ -12,6 +12,41 @@ mcp-unifi is designed to run on a trusted home or homelab LAN, behind your exist
 - **Local-network only**: the server talks to your UniFi gateway over the **local API** (X-API-Key header to `https://<gateway>/proxy/network/...`). It does not call out to any Ubiquiti cloud endpoint, does not require a UI account, and does not require Site Manager / Cloud Console enrollment.
 - **Self-signed gateway certs**: most home gateways present a self-signed certificate. `UNIFI_VERIFY_SSL` defaults to `false` for that reason. Set it to `true` once you've installed a real certificate.
 
+## Read-only mode
+
+Set `MCP_UNIFI_READONLY=true` and the server becomes structurally incapable of changing anything. Every tool that mutates is dropped from `tools/list` and refused on `tools/call`; read tools behave exactly as before.
+
+Both halves matter. Hiding a tool from the listing only removes the suggestion — a client that hard-codes a tool name, replays a cached manifest, or simply guesses would still reach the tool body. The call-time refusal is the control; the listing filter is what keeps a model from trying in the first place. The refusal is the standard `{"error": ..., "stub_mode": ...}` envelope every other tool failure uses, so no caller needs a second error path.
+
+This is **defense in depth on top of a read-only UniFi API key**, not a substitute. Give the server a read-only key and the controller refuses writes; add this setting and the server never attempts one. Use both. Reach for the flag when the server is exposed to an agent you are still evaluating, during an audit or incident review where nothing should change, or on a second instance you keep pointed at production for reads while a separate instance holds write credentials.
+
+### How tools are classified
+
+Each tool declares its own classification at registration:
+
+```python
+@mcp.tool()
+@audited("list_networks", mutates=False)
+async def list_networks(...) -> str: ...
+```
+
+`mutates` is a required argument, and registration fails if a tool has not declared it — the server refuses to start rather than let an unclassified tool default into being callable. A test enumerates every registered tool and fails CI on the same condition, so a tool added later cannot silently slip through.
+
+Classification is deliberately **not** derived from tool names. Twelve mutating tools carry none of the write-shaped prefixes a name-based gate would match:
+
+`confirm_destructive_action`, `restore_config`, `block_client`, `unblock_client`, `quarantine_client`, `reconnect_client`, `restart_device`, `rename_device`, `locate_device`, `toggle_traffic_rule`, `toggle_traffic_route`, `trigger_speedtest`
+
+The first is the reason the shortcut is unusable: `confirm_destructive_action` is the tool that *executes* a queued delete. A prefix-matching gate would ship a "read-only" server that still commits deletions.
+
+Judgment calls, recorded so they are not re-litigated:
+
+- **`trigger_speedtest` mutates.** It changes no configuration, but it makes the gateway saturate the WAN for 30-60 seconds on demand. Read-only has to mean the server cannot make the hardware do work, not just that it cannot edit config. `get_speedtest_results` stays available.
+- **`locate_device` mutates.** It flashes a physical LED until something turns it off. Changing what the hardware is doing in the room is not a read.
+- **`rename_device` mutates.** Cosmetic, but persisted, and it is the label every other tool's output shows.
+- **`backup_config` is a read.** It is a fan-out of GETs returned to the caller; it writes nothing to the controller. Taking a backup is exactly what you want to still be able to do in read-only mode.
+- **`get_console_health` and `get_console_firmware` are reads** even though the console path may POST a login. Authenticating is how the server reads UniFi OS at all, and `get_console_health` is the one tool that still answers when the Network application is down.
+- **Every `delete_*` tool mutates**, including its preview phase. Preview-then-confirm is an interlock against mistakes, not an access control.
+
 ## Secret handling
 
 - `UNIFI_API_KEY` and all per-controller `api_key` values are wrapped in Pydantic's `SecretStr`. Reading the cleartext requires `.get_secret_value()`; `repr()` and structured logging never echo the raw key.

--- a/docs/site/src/content/docs/install/docker.md
+++ b/docs/site/src/content/docs/install/docker.md
@@ -66,6 +66,8 @@ The example builds from local source. For the published image, change `build: .`
 
 The container runs as **UID 1000**, no shell, with a **read-only root filesystem** (`/tmp` is `tmpfs`) and `no-new-privileges`.
 
+To also make the server unable to change anything on the controller, add `MCP_UNIFI_READONLY=true` to your `.env`. Mutating tools are then hidden from `tools/list` and refused on `tools/call`; reads are unaffected. Pair it with a read-only UniFi API key rather than treating either as sufficient alone — see the [Security guide](/mcp-unifi/guides/security/#read-only-mode).
+
 ## Verify
 
 Send a `tools/list` request to confirm the server is alive and the right modules are loaded. Include the bearer token you minted above:

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -63,6 +63,24 @@ The Streamable HTTP transport is secure by default. See the [Authentication guid
 | `MCP_UNIFI_AUTH_REQUIRED` | bool | `true` | no | When `true`, the HTTP transport refuses to start without tokens. Set to `false` only on a loopback-bound single-host deployment. Stdio transport ignores this. |
 | `MCP_UNIFI_AUTH_TOKENS` | CSV string | `""` | HTTP + auth on | Comma-separated bearer tokens. Each entry is one of: a bare token (auto-assigned `client-N`), a `name:token` pair (recommended — name shows up in the audit log), or a `name:token:module1\|module2` triple to scope a client to specific modules. Pipe-separated because comma is the entry delimiter. Known modules: `network`, `protect`, `access`; `*` means all. |
 
+## Read-only mode
+
+| Variable | Type | Default | Required | Notes |
+|---|---|---|---|---|
+| `MCP_UNIFI_READONLY` | bool | `false` | no | When `true`, every tool that changes state is hidden from `tools/list` and refused on `tools/call`. Applies to both transports. Refusals come back as the standard `{"error": ..., "stub_mode": ...}` envelope, so callers need no new error handling. See the [Security guide](/mcp-unifi/guides/security/#read-only-mode). |
+
+Read-only mode is defense in depth on top of a read-only UniFi API key, not a
+replacement for one. The key decides what the controller will accept; this
+setting decides what the server is willing to attempt.
+
+Classification is per tool and explicit: each tool declares `mutates=True` or
+`mutates=False` at registration, and the server refuses to start if any
+registered tool has not declared one. It is not inferred from tool names —
+twelve mutating tools (`confirm_destructive_action`, `restore_config`,
+`block_client`, `restart_device`, `locate_device`, `trigger_speedtest`, and
+others) carry no `create_`/`update_`/`delete_`/`set_` prefix, so a name-based
+gate would leave them callable.
+
 ## Logging
 
 | Variable | Type | Default | Required | Notes |

--- a/src/mcp_unifi/config.py
+++ b/src/mcp_unifi/config.py
@@ -112,6 +112,21 @@ class Settings(BaseSettings):
     )
 
     # ------------------------------------------------------------------
+    # Read-only write gate (v0.21.0+)
+    # ------------------------------------------------------------------
+    readonly: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("MCP_UNIFI_READONLY", "readonly"),
+        description=(
+            "If True, every tool that changes state is hidden from tools/list "
+            "and refused on tools/call. Defense in depth on top of a read-only "
+            "UniFi API key: the key is the authority, this makes the server "
+            "unable to try. Default False so existing deployments are "
+            "unaffected. Env var: MCP_UNIFI_READONLY."
+        ),
+    )
+
+    # ------------------------------------------------------------------
     # Response shaping
     # ------------------------------------------------------------------
     force_full_text_responses: bool = Field(
@@ -450,6 +465,7 @@ class Settings(BaseSettings):
         """
         return {
             "stub_mode": self.stub_mode,
+            "readonly": self.readonly,
             "controllers_file": str(self.controllers_file) if self.controllers_file else None,
             "controllers": [
                 {

--- a/src/mcp_unifi/dispatcher.py
+++ b/src/mcp_unifi/dispatcher.py
@@ -35,6 +35,8 @@ from mcp_unifi.clients.protect import ProtectClient
 from mcp_unifi.clients.protect_stubs import make_protect_stub_state
 from mcp_unifi.clients.stubs import make_stub_state
 from mcp_unifi.clients.unifi import UniFiClient, UniFiError
+from mcp_unifi.modules._audit import tool_mutates
+from mcp_unifi.scoping import MUTATING_TAG
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -57,6 +59,20 @@ class UnknownControllerError(KeyError):
 
 class UnknownModuleError(ValueError):
     """Raised when ``MCP_UNIFI_MODULES_ENABLED`` references an unknown module."""
+
+
+class UnclassifiedToolError(RuntimeError):
+    """Raised when a registered tool never declared whether it mutates.
+
+    The read-only write gate can only be trusted if the classification is
+    total. Rather than default an unclassified tool to "read" (which would
+    ship a read-only mode that silently permits a new mutating tool) or to
+    "write" (which would silently break a new read tool and teach people to
+    distrust the gate), registration fails and the server does not start.
+
+    Fix: add the required ``mutates=`` argument to the tool's ``@audited(...)``
+    decorator.
+    """
 
 
 class ProtectNotAvailableError(RuntimeError):
@@ -347,18 +363,23 @@ def register_modules(
 
     Returns the tuple of module names actually registered (in order).
 
-    Side effect: each newly-registered tool is tagged with its module name
-    (``"network"``, ``"protect"``, ``"access"``) via FastMCP's ``tool.tags``
-    set. The scope-filter middleware
-    (:class:`mcp_unifi.scoping.ScopeMiddleware`) reads those tags at
-    request time to decide which tools a given client_id may see and call.
-    Tagging happens here — at the one place that already knows the
-    module→tool relationship — instead of inside every ``@mcp.tool()``
-    call site across ~20 sub-modules.
+    Side effect: each newly-registered tool is tagged via FastMCP's
+    ``tool.tags`` set with (a) its module name (``"network"``, ``"protect"``,
+    ``"access"``) and (b) :data:`~mcp_unifi.scoping.MUTATING_TAG` when the tool
+    declared ``mutates=True``. The two middlewares in
+    :mod:`mcp_unifi.scoping` read those tags at request time to decide which
+    tools a given client_id may see and call, and which tools are refused in
+    read-only mode. Tagging happens here — at the one place that already
+    enumerates newly-registered tools — instead of inside every
+    ``@mcp.tool()`` call site across ~20 sub-modules.
 
     Raises:
         UnknownModuleError: ``MCP_UNIFI_MODULES_ENABLED`` references a module
             that doesn't exist in ``mcp_unifi.modules``.
+        UnclassifiedToolError: a registered tool has no ``mutates``
+            declaration, or the tool list could not be enumerated at all (in
+            which case no classification could be applied and the write gate
+            would silently have nothing to filter on).
     """
     enabled = _enabled_modules()
     registered: list[str] = []
@@ -371,6 +392,17 @@ def register_modules(
         register_fn(mcp, settings, registry)
         _tag_new_tools(mcp, module_name=name, existing=before)
         registered.append(name)
+    if registered and not _iter_registered_tools(mcp):
+        # Every known module registers tools, so an empty list means
+        # ``_iter_registered_tools`` lost its grip on FastMCP's internals.
+        # Tagging would then be a silent no-op and the write gate would see
+        # no mutating tools to hide. Refuse to start instead.
+        raise UnclassifiedToolError(
+            "registered modules "
+            f"{registered} but could not enumerate any tool on the FastMCP "
+            "instance, so no tool could be tagged. The write gate and per-client "
+            "scoping both depend on those tags; refusing to start."
+        )
     logger.info(
         "registered modules",
         extra={"modules": registered, "controllers": registry.names()},
@@ -403,15 +435,35 @@ def _tool_names(mcp: FastMCP) -> set[str]:
 
 
 def _tag_new_tools(mcp: FastMCP, *, module_name: str, existing: set[str]) -> None:
-    """Add ``module_name`` to ``tool.tags`` for every tool registered since ``existing``."""
+    """Tag every tool registered since ``existing`` with its module and write class.
+
+    Raises:
+        UnclassifiedToolError: the tool declared no ``mutates`` value, or its
+            ``tags`` set is unreadable so no tag could be applied.
+    """
     for tool in _iter_registered_tools(mcp):
         name = getattr(tool, "name", "")
         if not name or name in existing:
             continue
         tags = getattr(tool, "tags", None)
+        mutates = tool_mutates(name)
+        if mutates is None:
+            raise UnclassifiedToolError(
+                f"tool '{name}' (module '{module_name}') did not declare whether "
+                f"it mutates state. Add the required ``mutates=`` argument to its "
+                f"@audited(...) decorator: mutates=True if calling it changes "
+                f"controller config, device state, or makes the controller do "
+                f"work; mutates=False for a pure read."
+            )
         if tags is None:
-            continue
+            raise UnclassifiedToolError(
+                f"tool '{name}' (module '{module_name}') exposes no tags set, so "
+                f"its module and write classification cannot be attached. "
+                f"Per-client scoping and read-only mode both read those tags."
+            )
         tags.add(module_name)
+        if mutates:
+            tags.add(MUTATING_TAG)
 
 
 __all__ = [
@@ -420,6 +472,7 @@ __all__ = [
     "AccessNotAvailableError",
     "ControllerRegistry",
     "ProtectNotAvailableError",
+    "UnclassifiedToolError",
     "UnknownControllerError",
     "UnknownModuleError",
     "build_registry",

--- a/src/mcp_unifi/modules/_audit.py
+++ b/src/mcp_unifi/modules/_audit.py
@@ -1,10 +1,36 @@
-"""Audit decorator for MCP tool functions.
+"""Audit decorator and write-classification for MCP tool functions.
 
-Step 4 wires every tool through a small ``@audited("<tool_name>")`` wrapper so
-every invocation emits one :class:`mcp_unifi.audit.AuditEvent` to the configured
-sink. The decorator deliberately lives at the **tool layer** (not the backend
-method layer) so the captured envelope reflects user-facing tool intent: the
-original kwargs, the original tool name, the controller the caller asked for.
+Step 4 wires every tool through a small ``@audited("<tool_name>", mutates=...)``
+wrapper so every invocation emits one :class:`mcp_unifi.audit.AuditEvent` to the
+configured sink. The decorator deliberately lives at the **tool layer** (not the
+backend method layer) so the captured envelope reflects user-facing tool intent:
+the original kwargs, the original tool name, the controller the caller asked for.
+
+Read/write classification (v0.21)
+---------------------------------
+``mutates`` is a **required** keyword argument. It declares whether the tool
+changes state anywhere outside this process — controller configuration, device
+state, or controller-side work. :class:`mcp_unifi.scoping.WriteGateMiddleware`
+uses it to enforce ``MCP_UNIFI_READONLY``.
+
+Why here, and why required:
+
+* It is declared at the registration site, next to the tool body and its
+  ``Side effects:`` docstring, so a reviewer classifies and implements in the
+  same diff.
+* Being required makes the gate fail closed at *import* time. Adding a tool
+  without classifying it raises ``TypeError`` and the server refuses to boot —
+  there is no default that silently leaves a new mutating tool callable while
+  ``MCP_UNIFI_READONLY=true``.
+* It reuses the decorator every tool already carries rather than adding a
+  parallel mechanism.
+
+Classification is recorded in a process-level registry keyed by tool name
+(:func:`tool_mutates`) rather than as an attribute on the wrapped function:
+FastMCP re-wraps tool callables during registration, so an attribute set here
+is not guaranteed to survive onto ``Tool.fn``. The registry is the value the
+dispatcher reads when it tags tools, and it is what the completeness test in
+``tests/test_write_gate.py`` enumerates.
 
 Design notes
 ------------
@@ -34,6 +60,34 @@ from mcp_unifi import audit
 
 P = ParamSpec("P")
 R = TypeVar("R")
+
+#: ``{tool_name: mutates}`` for every tool decorated with :func:`audited`.
+#: Populated at decoration time (i.e. when a module's ``register()`` runs).
+_CLASSIFICATION: dict[str, bool] = {}
+
+
+class ToolClassificationConflictError(ValueError):
+    """Raised when one tool name is declared with two different ``mutates`` values.
+
+    Tool names are globally unique across modules, so two conflicting
+    declarations mean either a copy-paste error or a genuine name collision.
+    Either way the write gate could not answer "is this tool mutating?"
+    deterministically, so we refuse at registration rather than pick one.
+    """
+
+
+def tool_mutates(tool_name: str) -> bool | None:
+    """Return the declared ``mutates`` flag for ``tool_name``, or ``None``.
+
+    ``None`` means "never classified" and is treated as a hard error by
+    :func:`mcp_unifi.dispatcher.register_modules` — never as "read-only".
+    """
+    return _CLASSIFICATION.get(tool_name)
+
+
+def classified_tools() -> dict[str, bool]:
+    """Return a copy of the whole ``{tool_name: mutates}`` registry."""
+    return dict(_CLASSIFICATION)
 
 
 def _current_client_id() -> str | None:
@@ -69,6 +123,8 @@ def _coerce_result(value: Any) -> Any:
 
 def audited(
     tool_name: str,
+    *,
+    mutates: bool,
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
     """Wrap an async tool function so every call emits an audit event.
 
@@ -76,10 +132,25 @@ def audited(
         tool_name: The MCP tool name as registered with FastMCP. Must match
             the function name (or ``@mcp.tool(name=...)`` override) so audit
             log lines line up with what a caller actually invoked.
+        mutates: Required. ``True`` when calling the tool changes state outside
+            this process — controller configuration, device state (an LED, a
+            reboot, a deauth), or controller-side work (a speed test). ``False``
+            only when the tool is a pure read: it may call the controller, but
+            leaves it exactly as it found it. Read the tool's ``Side effects:``
+            docstring section and make them agree. Tools declared ``True`` are
+            hidden and refused when ``MCP_UNIFI_READONLY=true``.
 
     The wrapped function preserves its original signature, so FastMCP's schema
     introspection sees the same parameters it would for the bare function.
     """
+    previous = _CLASSIFICATION.get(tool_name)
+    if previous is not None and previous != mutates:
+        raise ToolClassificationConflictError(
+            f"tool {tool_name!r} was declared with mutates={previous} and again "
+            f"with mutates={mutates}. Tool names must be globally unique and "
+            f"carry one classification."
+        )
+    _CLASSIFICATION[tool_name] = mutates
 
     def decorator(fn: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
         @wraps(fn)
@@ -130,4 +201,9 @@ def audited(
     return decorator
 
 
-__all__ = ["audited"]
+__all__ = [
+    "ToolClassificationConflictError",
+    "audited",
+    "classified_tools",
+    "tool_mutates",
+]

--- a/src/mcp_unifi/modules/access/__init__.py
+++ b/src/mcp_unifi/modules/access/__init__.py
@@ -60,7 +60,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_doors")
+    @audited("list_doors", mutates=False)
     async def list_doors(controller: str = "default") -> str:
         """List every door bonded to the Access controller.
 
@@ -84,7 +84,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_door")
+    @audited("get_door", mutates=False)
     async def get_door(door_id: str, controller: str = "default") -> str:
         """Fetch one door's full record by ID.
 
@@ -111,7 +111,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_door_groups")
+    @audited("list_door_groups", mutates=False)
     async def list_door_groups(controller: str = "default") -> str:
         """List every door group defined on the controller.
 
@@ -137,7 +137,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_access_policies")
+    @audited("list_access_policies", mutates=False)
     async def list_access_policies(controller: str = "default") -> str:
         """List every access policy on the controller.
 
@@ -161,7 +161,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_access_policy")
+    @audited("get_access_policy", mutates=False)
     async def get_access_policy(policy_id: str, controller: str = "default") -> str:
         """Fetch one access policy's full record by ID.
 
@@ -192,7 +192,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_credentials")
+    @audited("list_credentials", mutates=False)
     async def list_credentials(controller: str = "default") -> str:
         """List every credential enrolled in the Access controller.
 
@@ -219,7 +219,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_credential")
+    @audited("get_credential", mutates=False)
     async def get_credential(credential_id: str, controller: str = "default") -> str:
         """Fetch one credential's full record by ID.
 
@@ -246,7 +246,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("audit_expiring_credentials")
+    @audited("audit_expiring_credentials", mutates=False)
     async def audit_expiring_credentials(
         days_ahead: int = 30,
         credential_type: str = "",
@@ -313,7 +313,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_visitors")
+    @audited("list_visitors", mutates=False)
     async def list_visitors(controller: str = "default") -> str:
         """List every visitor pass on the controller (active and expired).
 
@@ -341,7 +341,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_visitor")
+    @audited("get_visitor", mutates=False)
     async def get_visitor(visitor_id: str, controller: str = "default") -> str:
         """Fetch one visitor pass's full record by ID.
 
@@ -371,7 +371,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_access_events")
+    @audited("list_access_events", mutates=False)
     async def list_access_events(
         hours_back: int = 24,
         result: str = "",
@@ -412,7 +412,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_recent_access_events")
+    @audited("get_recent_access_events", mutates=False)
     async def get_recent_access_events(
         limit: int = 20,
         controller: str = "default",
@@ -440,7 +440,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("summarize_access_activity")
+    @audited("summarize_access_activity", mutates=False)
     async def summarize_access_activity(
         hours_back: int = 24,
         controller: str = "default",
@@ -505,7 +505,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("list_failed_access_attempts")
+    @audited("list_failed_access_attempts", mutates=False)
     async def list_failed_access_attempts(
         hours_back: int = 24,
         door_id: str = "",
@@ -545,7 +545,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_access_devices")
+    @audited("list_access_devices", mutates=False)
     async def list_access_devices(controller: str = "default") -> str:
         """List hubs, readers, relays, and intercoms bonded to the controller.
 
@@ -569,7 +569,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_access_device")
+    @audited("get_access_device", mutates=False)
     async def get_access_device(device_id: str, controller: str = "default") -> str:
         """Fetch one Access device's full record by ID.
 
@@ -600,7 +600,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("get_access_system_info")
+    @audited("get_access_system_info", mutates=False)
     async def get_access_system_info(controller: str = "default") -> str:
         """Return controller version, license tier, and capacity.
 
@@ -624,7 +624,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_access_users")
+    @audited("list_access_users", mutates=False)
     async def list_access_users(controller: str = "default") -> str:
         """List every user enrolled in the Access system.
 

--- a/src/mcp_unifi/modules/network/backup.py
+++ b/src/mcp_unifi/modules/network/backup.py
@@ -388,7 +388,12 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("backup_config")
+    # Classified read despite producing an artifact: every call is a fan-out of
+    # GETs, the envelope is returned to the caller, and nothing is written to
+    # the controller (this is NOT the UniFi OS ".unf backup file" endpoint,
+    # which would create a file on the console). Taking a backup is exactly
+    # what an operator wants to still be able to do in read-only mode.
+    @audited("backup_config", mutates=False)
     async def backup_config(controller: str = "default") -> str:
         """Snapshot every persistent resource on the controller into one envelope.
 
@@ -462,7 +467,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(envelope)
 
     @mcp.tool()
-    @audited("restore_config")
+    @audited("restore_config", mutates=True)
     async def restore_config(
         backup_json: BoundedJson,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/clients.py
+++ b/src/mcp_unifi/modules/network/clients.py
@@ -26,7 +26,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_clients")
+    @audited("list_clients", mutates=False)
     async def list_clients(controller: str = "default") -> str:
         """List currently active wireless and wired clients.
 
@@ -50,7 +50,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("block_client")
+    @audited("block_client", mutates=True)
     async def block_client(
         mac: str,
         controller: str = "default",
@@ -94,7 +94,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("unblock_client")
+    @audited("unblock_client", mutates=True)
     async def unblock_client(
         mac: str,
         controller: str = "default",
@@ -137,7 +137,9 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("reconnect_client")
+    # Classified mutating: nothing is persisted, but it deauths a live client off
+    # the network. Transient effects on someone's connectivity are still effects.
+    @audited("reconnect_client", mutates=True)
     async def reconnect_client(
         mac: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/composites.py
+++ b/src/mcp_unifi/modules/network/composites.py
@@ -86,7 +86,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("create_iot_network")
+    @audited("create_iot_network", mutates=True)
     async def create_iot_network(
         name: BoundedName,
         vlan_id: int,
@@ -297,7 +297,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("provision_homelab_service")
+    @audited("provision_homelab_service", mutates=True)
     async def provision_homelab_service(
         name: BoundedName,
         mac: str,
@@ -469,7 +469,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("quarantine_client")
+    @audited("quarantine_client", mutates=True)
     async def quarantine_client(
         mac: str,
         reason: BoundedText = "",
@@ -529,7 +529,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("create_guest_network")
+    @audited("create_guest_network", mutates=True)
     async def create_guest_network(
         name: BoundedName,
         ssid: BoundedSsid,
@@ -739,7 +739,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("audit_open_ports")
+    @audited("audit_open_ports", mutates=False)
     async def audit_open_ports(controller: str = "default") -> str:
         """Audit WAN-facing exposure (port forwards and WAN_IN accept rules).
 

--- a/src/mcp_unifi/modules/network/confirm.py
+++ b/src/mcp_unifi/modules/network/confirm.py
@@ -41,7 +41,12 @@ def register(mcp: FastMCP, settings: Settings, _registry: ControllerRegistry) ->
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("confirm_destructive_action")
+    # Classified mutating, and this is the classification the whole write gate
+    # turns on. The tool's own name carries no write-shaped prefix, so any gate
+    # that keyed on ``create_``/``update_``/``delete_``/``set_`` would leave it
+    # callable — a "read-only" server that still executes a queued delete. It
+    # runs the mutation; it is mutating.
+    @audited("confirm_destructive_action", mutates=True)
     async def confirm_destructive_action(token: str) -> str:
         """Execute a queued destructive action by its preview token.
 

--- a/src/mcp_unifi/modules/network/console.py
+++ b/src/mcp_unifi/modules/network/console.py
@@ -364,7 +364,12 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("get_console_health")
+    # Classified read even though the console-session path may POST /api/auth/login:
+    # authenticating is how this server reads UniFi OS at all, it creates a session
+    # rather than changing any managed state, and the same login backs the other
+    # console read tools. If logging in were classified mutating, read-only mode
+    # would lose the one tool that still answers when Network is down.
+    @audited("get_console_health", mutates=False)
     async def get_console_health(controller: str = "default") -> str:
         """Diagnose the gateway's two layers separately: UniFi OS and Network.
 
@@ -430,7 +435,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(verdict)
 
     @mcp.tool()
-    @audited("get_console_info")
+    @audited("get_console_info", mutates=False)
     async def get_console_info(controller: str = "default") -> str:
         """Show UniFi OS console identity and connectivity, independent of Network.
 
@@ -521,7 +526,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(info)
 
     @mcp.tool()
-    @audited("get_console_firmware")
+    @audited("get_console_firmware", mutates=False)
     async def get_console_firmware(controller: str = "default") -> str:
         """Show UniFi OS firmware and available-update state.
 

--- a/src/mcp_unifi/modules/network/content_filtering.py
+++ b/src/mcp_unifi/modules/network/content_filtering.py
@@ -58,7 +58,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("list_content_filters")
+    @audited("list_content_filters", mutates=False)
     async def list_content_filters(controller: str = "default") -> str:
         """List DNS content-filtering profiles (category blocking, safe-search).
 
@@ -84,7 +84,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_content_filter_details")
+    @audited("get_content_filter_details", mutates=False)
     async def get_content_filter_details(filter_id: str, controller: str = "default") -> str:
         """Show one content-filtering profile's full record by ``_id``.
 
@@ -114,7 +114,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(target)
 
     @mcp.tool()
-    @audited("update_content_filter")
+    @audited("update_content_filter", mutates=True)
     async def update_content_filter(
         filter_id: str,
         updates: dict[str, Any],
@@ -185,7 +185,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_content_filter")
+    @audited("delete_content_filter", mutates=True)
     async def delete_content_filter(
         filter_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/devices.py
+++ b/src/mcp_unifi/modules/network/devices.py
@@ -140,7 +140,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_devices")
+    @audited("list_devices", mutates=False)
     async def list_devices(controller: str = "default") -> str:
         """List every UniFi device adopted by this controller.
 
@@ -167,7 +167,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("restart_device")
+    @audited("restart_device", mutates=True)
     async def restart_device(
         mac: str,
         controller: str = "default",
@@ -213,7 +213,11 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("locate_device")
+    # Classified mutating: no configuration changes, but the device's status LED
+    # physically starts flashing and stays that way until something turns it off.
+    # A control that let an agent change what the hardware is doing in the room
+    # while calling itself read-only would be misnamed.
+    @audited("locate_device", mutates=True)
     async def locate_device(
         mac: str,
         on: bool = True,
@@ -260,7 +264,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("set_port_state")
+    @audited("set_port_state", mutates=True)
     async def set_port_state(
         device_mac: str,
         port_idx: int,
@@ -340,7 +344,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_device_radios")
+    @audited("get_device_radios", mutates=False)
     async def get_device_radios(device_mac: str, controller: str = "default") -> str:
         """Show per-radio RF settings for an access point.
 
@@ -460,7 +464,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("set_radio_tx_power")
+    @audited("set_radio_tx_power", mutates=True)
     async def set_radio_tx_power(
         device_mac: str,
         band: str,
@@ -513,7 +517,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("set_radio_min_rssi")
+    @audited("set_radio_min_rssi", mutates=True)
     async def set_radio_min_rssi(
         device_mac: str,
         band: str,
@@ -564,7 +568,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("set_radio_channel")
+    @audited("set_radio_channel", mutates=True)
     async def set_radio_channel(
         device_mac: str,
         band: str,
@@ -623,7 +627,11 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("rename_device")
+    # Classified mutating: the change is cosmetic (display name only, no RF or
+    # traffic impact) but it is still a persisted PUT to the controller's
+    # device record, and it is the identifier every other tool's output and
+    # every dashboard reads back. Cosmetic writes are still writes.
+    @audited("rename_device", mutates=True)
     async def rename_device(
         device_mac: str,
         name: BoundedName,

--- a/src/mcp_unifi/modules/network/dhcp.py
+++ b/src/mcp_unifi/modules/network/dhcp.py
@@ -28,7 +28,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_dhcp_leases")
+    @audited("list_dhcp_leases", mutates=False)
     async def list_dhcp_leases(controller: str = "default") -> str:
         """List static DHCP reservations on the controller.
 
@@ -52,7 +52,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("create_static_dhcp_lease")
+    @audited("create_static_dhcp_lease", mutates=True)
     async def create_static_dhcp_lease(
         mac: str,
         ip: str,
@@ -113,7 +113,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_static_dhcp_lease")
+    @audited("update_static_dhcp_lease", mutates=True)
     async def update_static_dhcp_lease(
         mac: str,
         fixed_ip: str,
@@ -191,7 +191,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_static_dhcp_lease")
+    @audited("delete_static_dhcp_lease", mutates=True)
     async def delete_static_dhcp_lease(
         lease_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/drift.py
+++ b/src/mcp_unifi/modules/network/drift.py
@@ -405,7 +405,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("audit_network_drift")
+    @audited("audit_network_drift", mutates=False)
     async def audit_network_drift(
         spec_yaml: BoundedYaml,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/dynamic_dns.py
+++ b/src/mcp_unifi/modules/network/dynamic_dns.py
@@ -54,7 +54,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return next((d for d in entries if isinstance(d, dict) and d.get("_id") == ddns_id), None)
 
     @mcp.tool()
-    @audited("list_dynamic_dns")
+    @audited("list_dynamic_dns", mutates=False)
     async def list_dynamic_dns(controller: str = "default") -> str:
         """List Dynamic DNS update configurations on the controller.
 
@@ -81,7 +81,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_dynamic_dns_details")
+    @audited("get_dynamic_dns_details", mutates=False)
     async def get_dynamic_dns_details(ddns_id: str, controller: str = "default") -> str:
         """Show one Dynamic DNS config's full record by ``_id``.
 
@@ -110,7 +110,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(redact(target))
 
     @mcp.tool()
-    @audited("create_dynamic_dns")
+    @audited("create_dynamic_dns", mutates=True)
     async def create_dynamic_dns(
         service: str,
         host_name: BoundedHostname,
@@ -180,7 +180,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_dynamic_dns")
+    @audited("update_dynamic_dns", mutates=True)
     async def update_dynamic_dns(
         ddns_id: str,
         updates: dict[str, Any],
@@ -235,7 +235,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_dynamic_dns")
+    @audited("delete_dynamic_dns", mutates=True)
     async def delete_dynamic_dns(
         ddns_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/firewall.py
+++ b/src/mcp_unifi/modules/network/firewall.py
@@ -32,7 +32,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_firewall_rules")
+    @audited("list_firewall_rules", mutates=False)
     async def list_firewall_rules(controller: str = "default") -> str:
         """List every firewall rule on the controller.
 
@@ -56,7 +56,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("create_firewall_rule")
+    @audited("create_firewall_rule", mutates=True)
     async def create_firewall_rule(
         name: BoundedName,
         ruleset: str,
@@ -169,7 +169,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_firewall_rule")
+    @audited("update_firewall_rule", mutates=True)
     async def update_firewall_rule(
         rule_id: str,
         updates: dict[str, Any],
@@ -219,7 +219,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_firewall_rule")
+    @audited("delete_firewall_rule", mutates=True)
     async def delete_firewall_rule(
         rule_id: str,
         controller: str = "default",
@@ -299,7 +299,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_firewall_groups")
+    @audited("list_firewall_groups", mutates=False)
     async def list_firewall_groups(controller: str = "default") -> str:
         """List reusable firewall groups (address, IPv6-address, and port groups).
 
@@ -326,7 +326,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_firewall_group_details")
+    @audited("get_firewall_group_details", mutates=False)
     async def get_firewall_group_details(group_id: str, controller: str = "default") -> str:
         """Show one firewall group's full record by ``_id``.
 
@@ -356,7 +356,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(target)
 
     @mcp.tool()
-    @audited("create_firewall_group")
+    @audited("create_firewall_group", mutates=True)
     async def create_firewall_group(
         name: BoundedName,
         group_type: str,
@@ -416,7 +416,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_firewall_group")
+    @audited("update_firewall_group", mutates=True)
     async def update_firewall_group(
         group_id: str,
         name: BoundedName = "",
@@ -505,7 +505,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_firewall_group")
+    @audited("delete_firewall_group", mutates=True)
     async def delete_firewall_group(
         group_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/guest_portal.py
+++ b/src/mcp_unifi/modules/network/guest_portal.py
@@ -140,7 +140,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("get_guest_portal")
+    @audited("get_guest_portal", mutates=False)
     async def get_guest_portal(controller: str = "default") -> str:
         """Show the guest captive-portal configuration for the site.
 
@@ -180,7 +180,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(redact(_project(record)))
 
     @mcp.tool()
-    @audited("set_guest_portal")
+    @audited("set_guest_portal", mutates=True)
     async def set_guest_portal(
         portal_enabled: bool | None = None,
         auth: str | None = None,

--- a/src/mcp_unifi/modules/network/honeypot.py
+++ b/src/mcp_unifi/modules/network/honeypot.py
@@ -88,7 +88,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_honeypots")
+    @audited("list_honeypots", mutates=False)
     async def list_honeypots(controller: str = "default") -> str:
         """List configured honeypots and the global honeypot toggle.
 
@@ -122,7 +122,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("create_honeypot")
+    @audited("create_honeypot", mutates=True)
     async def create_honeypot(
         network_id: str,
         ip: str,
@@ -203,7 +203,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(_enrich(new_entry, networks))
 
     @mcp.tool()
-    @audited("delete_honeypot")
+    @audited("delete_honeypot", mutates=True)
     async def delete_honeypot(
         id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/ipv6.py
+++ b/src/mcp_unifi/modules/network/ipv6.py
@@ -226,7 +226,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return wans[0]
 
     @mcp.tool()
-    @audited("get_wan_ipv6")
+    @audited("get_wan_ipv6", mutates=False)
     async def get_wan_ipv6(wan_name: str = "", controller: str = "default") -> str:
         """Show the current IPv6 configuration of the WAN uplink(s).
 
@@ -266,7 +266,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json({"controller": controller, "wan_ipv6": view})
 
     @mcp.tool()
-    @audited("set_wan_ipv6")
+    @audited("set_wan_ipv6", mutates=True)
     async def set_wan_ipv6(
         connection_type: str = "",
         prefix_delegation: str = "",
@@ -417,7 +417,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("set_lan_ipv6")
+    @audited("set_lan_ipv6", mutates=True)
     async def set_lan_ipv6(
         network_id: str,
         interface_type: str = "",

--- a/src/mcp_unifi/modules/network/observability.py
+++ b/src/mcp_unifi/modules/network/observability.py
@@ -23,7 +23,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("get_site_health")
+    @audited("get_site_health", mutates=False)
     async def get_site_health(controller: str = "default") -> str:
         """Report per-subsystem health (wan, lan, wlan, www, vpn).
 
@@ -46,7 +46,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_wan_status")
+    @audited("get_wan_status", mutates=False)
     async def get_wan_status(controller: str = "default") -> str:
         """Report current WAN status: link, ISP, public IP, throughput, latency.
 
@@ -70,7 +70,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_events")
+    @audited("list_events", mutates=False)
     async def list_events(limit: int = 50, controller: str = "default") -> str:
         """List recent controller events (connections, disconnections, etc.).
 
@@ -95,7 +95,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_alarms")
+    @audited("list_alarms", mutates=False)
     async def list_alarms(
         limit: int = 50,
         archived: bool = False,
@@ -126,7 +126,13 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("trigger_speedtest")
+    # Classified mutating even though it changes no configuration: it issues a
+    # POST that makes the gateway saturate the WAN for ~30-60s and appends a
+    # result row. "Read-only" has to mean the server cannot make the gateway do
+    # work on command, not merely that it cannot edit config — an agent that can
+    # trigger speed tests in a loop is a denial-of-service on the uplink.
+    # ``get_speedtest_results`` (read) still returns previously-run tests.
+    @audited("trigger_speedtest", mutates=True)
     async def trigger_speedtest(controller: str = "default") -> str:
         """Kick off a UniFi speed test on the WAN link.
 
@@ -149,7 +155,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_speedtest_results")
+    @audited("get_speedtest_results", mutates=False)
     async def get_speedtest_results(limit: int = 10, controller: str = "default") -> str:
         """List recent speed-test results, newest first.
 
@@ -175,7 +181,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_top_talkers")
+    @audited("list_top_talkers", mutates=False)
     async def list_top_talkers(limit: int = 10, controller: str = "default") -> str:
         """List top clients by total bytes (DPI by-station report).
 

--- a/src/mcp_unifi/modules/network/port_forwards.py
+++ b/src/mcp_unifi/modules/network/port_forwards.py
@@ -28,7 +28,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_port_forwards")
+    @audited("list_port_forwards", mutates=False)
     async def list_port_forwards(controller: str = "default") -> str:
         """List every port-forward (DNAT) rule on the controller.
 
@@ -51,7 +51,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("create_port_forward")
+    @audited("create_port_forward", mutates=True)
     async def create_port_forward(
         name: BoundedName,
         fwd: str,
@@ -118,7 +118,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_port_forward")
+    @audited("update_port_forward", mutates=True)
     async def update_port_forward(
         forward_id: str,
         updates: dict[str, Any],
@@ -191,7 +191,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_port_forward")
+    @audited("delete_port_forward", mutates=True)
     async def delete_port_forward(
         forward_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/port_profiles.py
+++ b/src/mcp_unifi/modules/network/port_profiles.py
@@ -27,7 +27,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_port_profiles")
+    @audited("list_port_profiles", mutates=False)
     async def list_port_profiles(controller: str = "default") -> str:
         """List switch port profiles configured on the controller.
 
@@ -52,7 +52,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("create_port_profile")
+    @audited("create_port_profile", mutates=True)
     async def create_port_profile(
         name: BoundedName,
         native_networkconf_id: str = "",
@@ -114,7 +114,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_port_profile")
+    @audited("update_port_profile", mutates=True)
     async def update_port_profile(
         profile_id: str,
         updates: dict[str, Any],
@@ -166,7 +166,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_port_profile")
+    @audited("delete_port_profile", mutates=True)
     async def delete_port_profile(
         profile_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/routing.py
+++ b/src/mcp_unifi/modules/network/routing.py
@@ -45,7 +45,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_routes")
+    @audited("list_routes", mutates=False)
     async def list_routes(controller: str = "default") -> str:
         """List user-defined static (next-hop) routes on the controller.
 
@@ -71,7 +71,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_route_details")
+    @audited("get_route_details", mutates=False)
     async def get_route_details(route_id: str, controller: str = "default") -> str:
         """Show one static route's full record by ``_id``.
 
@@ -99,7 +99,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(target)
 
     @mcp.tool()
-    @audited("create_route")
+    @audited("create_route", mutates=True)
     async def create_route(
         name: BoundedName,
         destination: str,
@@ -169,7 +169,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_route")
+    @audited("update_route", mutates=True)
     async def update_route(
         route_id: str,
         updates: dict[str, Any],
@@ -218,7 +218,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_route")
+    @audited("delete_route", mutates=True)
     async def delete_route(
         route_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/stats.py
+++ b/src/mcp_unifi/modules/network/stats.py
@@ -49,7 +49,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("get_system_info")
+    @audited("get_system_info", mutates=False)
     async def get_system_info(controller: str = "default") -> str:
         """Report controller/system info: version, uptime, device type.
 
@@ -75,7 +75,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_gateway_stats")
+    @audited("get_gateway_stats", mutates=False)
     async def get_gateway_stats(controller: str = "default") -> str:
         """Report gateway resource stats: CPU, memory, temperature, throughput.
 
@@ -101,7 +101,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_device_stats")
+    @audited("get_device_stats", mutates=False)
     async def get_device_stats(mac: str, controller: str = "default") -> str:
         """Report per-device stats for one UniFi device by MAC.
 
@@ -131,7 +131,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_client_stats")
+    @audited("get_client_stats", mutates=False)
     async def get_client_stats(mac: str, controller: str = "default") -> str:
         """Report per-client traffic, signal, and uptime for one client by MAC.
 
@@ -163,7 +163,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_client_sessions")
+    @audited("get_client_sessions", mutates=False)
     async def get_client_sessions(
         mac: str = "",
         hours: int = 24,
@@ -204,7 +204,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_anomalies")
+    @audited("get_anomalies", mutates=False)
     async def get_anomalies(controller: str = "default") -> str:
         """List client-impacting anomalies the controller has detected.
 

--- a/src/mcp_unifi/modules/network/teleport.py
+++ b/src/mcp_unifi/modules/network/teleport.py
@@ -75,7 +75,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("get_teleport_config")
+    @audited("get_teleport_config", mutates=False)
     async def get_teleport_config(controller: str = "default") -> str:
         """Return Teleport VPN state and any wireguard-server networks.
 
@@ -125,7 +125,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         )
 
     @mcp.tool()
-    @audited("set_teleport_enabled")
+    @audited("set_teleport_enabled", mutates=True)
     async def set_teleport_enabled(
         enabled: bool,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/threat_management.py
+++ b/src/mcp_unifi/modules/network/threat_management.py
@@ -68,7 +68,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("get_threat_management")
+    @audited("get_threat_management", mutates=False)
     async def get_threat_management(controller: str = "default") -> str:
         """Return current Threat Management (IDS/IPS) configuration.
 
@@ -97,7 +97,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(_project_get(record))
 
     @mcp.tool()
-    @audited("set_threat_management")
+    @audited("set_threat_management", mutates=True)
     async def set_threat_management(
         enabled: bool,
         mode: str = "ids",

--- a/src/mcp_unifi/modules/network/traffic.py
+++ b/src/mcp_unifi/modules/network/traffic.py
@@ -58,7 +58,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_traffic_rules")
+    @audited("list_traffic_rules", mutates=False)
     async def list_traffic_rules(controller: str = "default") -> str:
         """List v2 traffic rules (app/domain/IP-based allow & block policies).
 
@@ -82,7 +82,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_traffic_rule_details")
+    @audited("get_traffic_rule_details", mutates=False)
     async def get_traffic_rule_details(rule_id: str, controller: str = "default") -> str:
         """Show one traffic rule's full record by ``_id``.
 
@@ -110,7 +110,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(target)
 
     @mcp.tool()
-    @audited("create_traffic_rule")
+    @audited("create_traffic_rule", mutates=True)
     async def create_traffic_rule(
         rule: dict[str, Any],
         controller: str = "default",
@@ -165,7 +165,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_traffic_rule")
+    @audited("update_traffic_rule", mutates=True)
     async def update_traffic_rule(
         rule_id: str,
         updates: dict[str, Any],
@@ -222,7 +222,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("toggle_traffic_rule")
+    @audited("toggle_traffic_rule", mutates=True)
     async def toggle_traffic_rule(
         rule_id: str,
         enabled: bool,
@@ -288,7 +288,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     # ------------------------------------------------------------------
 
     @mcp.tool()
-    @audited("list_traffic_routes")
+    @audited("list_traffic_routes", mutates=False)
     async def list_traffic_routes(controller: str = "default") -> str:
         """List v2 traffic routes (policy-based routing, e.g. VPN-client routes).
 
@@ -313,7 +313,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_traffic_route_details")
+    @audited("get_traffic_route_details", mutates=False)
     async def get_traffic_route_details(route_id: str, controller: str = "default") -> str:
         """Show one traffic route's full record by ``_id``.
 
@@ -341,7 +341,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(target)
 
     @mcp.tool()
-    @audited("update_traffic_route")
+    @audited("update_traffic_route", mutates=True)
     async def update_traffic_route(
         route_id: str,
         updates: dict[str, Any] | None = None,
@@ -411,7 +411,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("toggle_traffic_route")
+    @audited("toggle_traffic_route", mutates=True)
     async def toggle_traffic_route(
         route_id: str,
         enabled: bool,

--- a/src/mcp_unifi/modules/network/vlans.py
+++ b/src/mcp_unifi/modules/network/vlans.py
@@ -34,7 +34,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_networks")
+    @audited("list_networks", mutates=False)
     async def list_networks(controller: str = "default") -> str:
         """List every network/VLAN configured on the controller.
 
@@ -67,7 +67,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_network_details")
+    @audited("get_network_details", mutates=False)
     async def get_network_details(
         network_id: str = "",
         name: BoundedName = "",
@@ -169,7 +169,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         return format_json(redact({"controller": controller, **sections}))
 
     @mcp.tool()
-    @audited("create_vlan")
+    @audited("create_vlan", mutates=True)
     async def create_vlan(
         name: BoundedName,
         vlan_id: int,
@@ -251,7 +251,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_vlan")
+    @audited("update_vlan", mutates=True)
     async def update_vlan(
         network_id: str,
         updates: dict[str, Any],
@@ -325,7 +325,11 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_vlan")
+    # Classified mutating even though this first phase only mints a preview
+    # token: it is half of one destructive operation, and preview-then-confirm
+    # is an interlock against mistakes, not an access control. Every ``delete_*``
+    # tool is classified the same way, as is ``confirm_destructive_action``.
+    @audited("delete_vlan", mutates=True)
     async def delete_vlan(
         network_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/network/wlans.py
+++ b/src/mcp_unifi/modules/network/wlans.py
@@ -34,7 +34,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_wlans")
+    @audited("list_wlans", mutates=False)
     async def list_wlans(controller: str = "default") -> str:
         """List every WiFi SSID configured on the controller.
 
@@ -66,7 +66,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_ap_groups")
+    @audited("list_ap_groups", mutates=False)
     async def list_ap_groups(controller: str = "default") -> str:
         """List access-point groups configured on the controller.
 
@@ -94,7 +94,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("create_wlan")
+    @audited("create_wlan", mutates=True)
     async def create_wlan(
         name: BoundedName,
         passphrase: BoundedSecret,
@@ -195,7 +195,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("update_wlan")
+    @audited("update_wlan", mutates=True)
     async def update_wlan(
         wlan_id: str,
         updates: dict[str, Any],
@@ -269,7 +269,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("delete_wlan")
+    @audited("delete_wlan", mutates=True)
     async def delete_wlan(
         wlan_id: str,
         controller: str = "default",

--- a/src/mcp_unifi/modules/protect/__init__.py
+++ b/src/mcp_unifi/modules/protect/__init__.py
@@ -61,7 +61,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
     err = make_err(settings)
 
     @mcp.tool()
-    @audited("list_cameras")
+    @audited("list_cameras", mutates=False)
     async def list_cameras(controller: str = "default") -> str:
         """List every camera bonded to the Protect controller.
 
@@ -86,7 +86,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_camera")
+    @audited("get_camera", mutates=False)
     async def get_camera(camera_id: str, controller: str = "default") -> str:
         """Fetch a single camera's full record by ID.
 
@@ -114,7 +114,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_motion_events")
+    @audited("list_motion_events", mutates=False)
     async def list_motion_events(
         camera_id: str = "",
         limit: int = 50,
@@ -150,7 +150,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_smart_detections")
+    @audited("list_smart_detections", mutates=False)
     async def list_smart_detections(
         detection_type: str = "person",
         camera_id: str = "",
@@ -193,7 +193,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_snapshot")
+    @audited("get_snapshot", mutates=False)
     async def get_snapshot(camera_id: str, controller: str = "default") -> str:
         """Fetch a current JPEG snapshot from a camera, base64-encoded.
 
@@ -228,7 +228,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("get_event_thumbnail")
+    @audited("get_event_thumbnail", mutates=False)
     async def get_event_thumbnail(event_id: str, controller: str = "default") -> str:
         """Fetch the JPEG thumbnail for a Protect event, base64-encoded.
 
@@ -263,7 +263,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_recordings")
+    @audited("list_recordings", mutates=False)
     async def list_recordings(
         camera_id: str,
         hours_back: int = 24,
@@ -294,7 +294,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("set_camera_recording_mode")
+    @audited("set_camera_recording_mode", mutates=True)
     async def set_camera_recording_mode(
         camera_id: str,
         mode: str,
@@ -342,7 +342,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("set_camera_privacy_mode")
+    @audited("set_camera_privacy_mode", mutates=True)
     async def set_camera_privacy_mode(
         camera_id: str,
         enabled: bool,
@@ -392,7 +392,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("set_motion_sensitivity")
+    @audited("set_motion_sensitivity", mutates=True)
     async def set_motion_sensitivity(
         camera_id: str,
         sensitivity: int,
@@ -443,7 +443,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("list_doorbell_messages")
+    @audited("list_doorbell_messages", mutates=False)
     async def list_doorbell_messages(controller: str = "default") -> str:
         """List doorbell cameras (those with ``isDoorbell=True``).
 
@@ -478,7 +478,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
             return err(str(exc))
 
     @mcp.tool()
-    @audited("provision_camera")
+    @audited("provision_camera", mutates=True)
     async def provision_camera(
         camera_id: str,
         recording_mode: str = "motion",

--- a/src/mcp_unifi/scoping.py
+++ b/src/mcp_unifi/scoping.py
@@ -1,5 +1,12 @@
-"""Per-client tool scoping for the HTTP transport.
+"""Tool-visibility middleware: per-client module scoping and the read-only write gate.
 
+Two filters live here because they are the same shape — decide from a tag the
+dispatcher already applied whether this caller may see and call this tool — and
+differ only in what they key on. :class:`ScopeMiddleware` keys on the caller's
+module allowlist. :class:`WriteGateMiddleware` keys on whether the tool mutates.
+
+Per-client tool scoping (HTTP transport)
+----------------------------------------
 Every tool registered on the FastMCP instance carries a module tag added
 by :func:`mcp_unifi.dispatcher.register_modules` (``"network"``,
 ``"protect"``, or ``"access"``). Every bearer token in
@@ -18,10 +25,23 @@ Why middleware and not per-tool ``auth=`` checks: adding an ``auth=``
 argument to every ``@mcp.tool()`` call site would touch every module.
 The middleware pattern keeps the concern in one file, keyed off tags the
 dispatcher already applies uniformly.
+
+Read-only write gate (both transports)
+--------------------------------------
+:class:`WriteGateMiddleware` is installed only when ``MCP_UNIFI_READONLY``
+is on. It hides and refuses every tool tagged :data:`MUTATING_TAG`, which
+the dispatcher applies from each tool's required
+``@audited(..., mutates=...)`` declaration.
+
+Where scoping asks "may *this caller* use this tool", the write gate asks
+"is *this server* willing to change anything at all". The second question
+has no per-client answer, which is why it keys on a tool property rather
+than on the caller's identity and applies on stdio as well as HTTP.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Sequence
 from typing import Any
@@ -32,12 +52,18 @@ from fastmcp.server.middleware.middleware import (
     Middleware,
     MiddlewareContext,
 )
-from fastmcp.tools.tool import Tool
+from fastmcp.tools.tool import Tool, ToolResult
 from mcp import types as mt
 
 logger = logging.getLogger("mcp_unifi.scoping")
 
 WILDCARD = "*"
+
+#: Tag added by :func:`mcp_unifi.dispatcher.register_modules` to every tool
+#: declared ``@audited(..., mutates=True)``. Lives in the same ``tool.tags``
+#: set as the module tags, so :func:`_tool_modules` filters it back out before
+#: any module-scope comparison.
+MUTATING_TAG = "mutating"
 
 
 class ScopeMiddleware(Middleware):
@@ -127,25 +153,116 @@ def _current_client_id() -> str | None:
 
 
 def _tool_modules(tool: Tool) -> set[str]:
-    return set(getattr(tool, "tags", None) or set())
+    """Return a tool's module tags, excluding the non-module write tag."""
+    return set(getattr(tool, "tags", None) or set()) - {MUTATING_TAG}
+
+
+def _tool_is_mutating(tool: Tool) -> bool:
+    return MUTATING_TAG in (getattr(tool, "tags", None) or set())
+
+
+async def _lookup_tool(
+    context: MiddlewareContext[mt.CallToolRequestParams], tool_name: str
+) -> Tool | None:
+    """Return the registered :class:`Tool` for ``tool_name``, or ``None``.
+
+    Uses the request's FastMCP context to look up the registered tool
+    without touching internal FastMCP state. ``None`` means "could not be
+    resolved" — an unknown name, or a context this middleware cannot read.
+    Both callers treat that as a denial, never as a permit.
+    """
+    fastmcp_ctx = context.fastmcp_context
+    if fastmcp_ctx is None:
+        return None
+    try:
+        return await fastmcp_ctx.fastmcp.get_tool(tool_name)
+    except Exception:
+        return None
 
 
 async def _resolve_tool_modules(
     context: MiddlewareContext[mt.CallToolRequestParams], tool_name: str
 ) -> set[str]:
-    """Return the module tag set for ``tool_name``, or empty set if unknown.
+    """Return the module tag set for ``tool_name``, or empty set if unknown."""
+    tool = await _lookup_tool(context, tool_name)
+    return set() if tool is None else _tool_modules(tool)
 
-    Uses the request's FastMCP context to look up the registered tool
-    without touching internal FastMCP state.
+
+class WriteGateMiddleware(Middleware):
+    """Hide and refuse every mutating tool while ``MCP_UNIFI_READONLY`` is on.
+
+    Installed only when :attr:`mcp_unifi.config.Settings.readonly` is True, so
+    a default deployment pays nothing. When it is installed:
+
+    * ``tools/list`` omits every tool tagged :data:`MUTATING_TAG`, so a model
+      is never shown a capability it cannot use.
+    * ``tools/call`` refuses those same tools before the call reaches the tool
+      body, so a caller that hard-codes a tool name, replays an old manifest,
+      or guesses gets nowhere. Hiding alone would be advisory; the call gate is
+      the control.
+
+    The refusal is the server's normal error envelope
+    (``{"error": ..., "stub_mode": ...}``), not a raised
+    :class:`~fastmcp.exceptions.ToolError`. Every tool in this server reports
+    failure that way — see the ``resolve_backend`` docstring for the same
+    reasoning applied to dispatcher errors — and a caller that already handles
+    tool errors should not need a second code path to handle this one.
+
+    Fail-closed by construction: a tool whose tags cannot be resolved is
+    refused. The classification itself is enforced upstream at registration
+    (:func:`mcp_unifi.dispatcher.register_modules` raises on any unclassified
+    tool), so an unresolvable tool here is an anomaly, and the safe reading of
+    an anomaly in a write gate is "assume it writes".
+
+    Args:
+        stub_mode: Value echoed as ``stub_mode`` in the refusal envelope, so
+            the envelope matches what a real tool would have returned.
     """
-    fastmcp_ctx = context.fastmcp_context
-    if fastmcp_ctx is None:
-        return set()
-    try:
-        tool = await fastmcp_ctx.fastmcp.get_tool(tool_name)
-    except Exception:
-        return set()
-    return _tool_modules(tool)
+
+    def __init__(self, *, stub_mode: bool) -> None:
+        self._stub_mode = stub_mode
+
+    async def on_list_tools(
+        self,
+        context: MiddlewareContext[mt.ListToolsRequest],
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
+        tools = await call_next(context)
+        return [t for t in tools if not _tool_is_mutating(t)]
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, Any],
+    ) -> Any:
+        tool_name = context.message.name
+        tool = await _lookup_tool(context, tool_name)
+        if tool is None or _tool_is_mutating(tool):
+            logger.warning(
+                "read-only mode refused a tool call",
+                extra={
+                    "tool": tool_name,
+                    "client_id": _current_client_id(),
+                    "resolved": tool is not None,
+                },
+            )
+            return self._refusal(tool_name)
+        return await call_next(context)
+
+    def _refusal(self, tool_name: str) -> ToolResult:
+        payload = json.dumps(
+            {
+                "error": (
+                    f"{tool_name} changes state and this server is running in "
+                    f"read-only mode (MCP_UNIFI_READONLY=true). No call was made "
+                    f"to the controller. Read tools are unaffected."
+                ),
+                "stub_mode": self._stub_mode,
+            },
+            indent=2,
+            default=str,
+        )
+        return ToolResult(content=[mt.TextContent(type="text", text=payload)])
 
 
-__all__ = ["WILDCARD", "ScopeMiddleware"]
+__all__ = ["MUTATING_TAG", "WILDCARD", "ScopeMiddleware", "WriteGateMiddleware"]

--- a/src/mcp_unifi/server.py
+++ b/src/mcp_unifi/server.py
@@ -52,7 +52,7 @@ from mcp_unifi.config import Settings, load_settings
 from mcp_unifi.dispatcher import build_registry, register_modules
 from mcp_unifi.logging_setup import configure_logging
 from mcp_unifi.responses import AdaptiveResponseMiddleware
-from mcp_unifi.scoping import WILDCARD, ScopeMiddleware
+from mcp_unifi.scoping import WILDCARD, ScopeMiddleware, WriteGateMiddleware
 
 logger = logging.getLogger("mcp_unifi.server")
 
@@ -152,6 +152,11 @@ def build_server(
     register_modules(mcp, settings, registry)
     _install_scope_middleware(mcp, settings)
     _install_adaptive_response_middleware(mcp, settings)
+    # Added last, so it sits innermost: FastMCP builds the chain in reverse
+    # registration order, which puts the write gate closest to the tool. A
+    # refusal therefore comes back out through the adaptive-response
+    # middleware and is framed exactly like any other tool error envelope.
+    _install_write_gate_middleware(mcp, settings)
     return mcp
 
 
@@ -188,6 +193,27 @@ def _install_scope_middleware(mcp: FastMCP, settings: Settings) -> None:
     logger.info(
         "per-client tool scoping enabled",
         extra={"scopes": {client_id: sorted(modules) for client_id, modules in scopes.items()}},
+    )
+
+
+def _install_write_gate_middleware(mcp: FastMCP, settings: Settings) -> None:
+    """Register the read-only write gate when ``MCP_UNIFI_READONLY`` is set.
+
+    Transport-independent on purpose: read-only is an operator posture for the
+    whole process, not a property of one client's credentials. A stdio install
+    driven by a desktop client benefits from it exactly as much as the
+    container does.
+
+    Not installed at all when the setting is off, so the default deployment
+    keeps ``tools/list`` and ``tools/call`` on the same path they were on
+    before this shipped.
+    """
+    if not settings.readonly:
+        return
+    mcp.add_middleware(WriteGateMiddleware(stub_mode=settings.stub_mode))
+    logger.warning(
+        "read-only mode enabled: every mutating tool is hidden from tools/list "
+        "and refused on tools/call (MCP_UNIFI_READONLY=true)"
     )
 
 

--- a/tests/test_audit_integration.py
+++ b/tests/test_audit_integration.py
@@ -189,7 +189,9 @@ async def test_audit_records_failure_and_reraises(
     """A tool that raises must produce a success=false audit entry and re-raise."""
     log_path, _ = file_sink_audit_log
 
-    @audited("synthetic_tool")
+    # ``mutates`` is required (v0.21.0 write gate); this synthetic tool is
+    # never registered with FastMCP, so the value only has to be declared.
+    @audited("synthetic_tool", mutates=True)
     async def boom(controller: str = "default", thing: str = "x") -> str:
         raise RuntimeError("explosive disassembly")
 

--- a/tests/test_write_gate.py
+++ b/tests/test_write_gate.py
@@ -1,0 +1,368 @@
+"""Tests for the read-only write gate (``MCP_UNIFI_READONLY``, v0.21.0).
+
+The gate has three layers and each is tested separately, because each one
+fails in a different silent way:
+
+* **Classification** (``@audited(..., mutates=...)``). Every registered tool
+  declares whether it mutates. The completeness test below enumerates the live
+  registration and fails if anything is unclassified, so a tool added later
+  cannot default into being callable in read-only mode.
+* **Visibility** (``tools/list``). A read-only client must not be shown a
+  mutating tool.
+* **Invocation** (``tools/call``). A caller that names a hidden tool anyway
+  must be refused, with the server's normal error envelope, before the tool
+  body runs. Hiding without refusing is a suggestion, not a control, so both
+  halves are asserted — including that the underlying state did not move.
+
+``test_prefix_classifier_would_have_missed_these`` is the regression test for
+the design that was rejected: classifying by name prefix
+(``create_``/``update_``/``delete_``/``set_``/``provision_``/``apply_``/
+``reboot``) leaves 13 mutating tools callable, one of which is
+``confirm_destructive_action`` — the tool that executes a queued delete. That
+list is pinned here so nobody re-derives the shortcut later and finds the tests
+still green.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from mcp_unifi.clients.stubs import StubState
+from mcp_unifi.config import Settings
+from mcp_unifi.dispatcher import UnclassifiedToolError, _tag_new_tools
+from mcp_unifi.modules._audit import audited, classified_tools
+from mcp_unifi.modules.network._common import make_err
+from mcp_unifi.scoping import MUTATING_TAG
+from mcp_unifi.server import build_server
+
+#: Mutating tools whose names carry none of the write-shaped prefixes a
+#: name-based classifier would key on. Pinned so the shortcut stays dead.
+NO_PREFIX_MUTATING_TOOLS: frozenset[str] = frozenset(
+    {
+        "backup_config",  # read; listed here because a prefix gate would also miss it
+        "block_client",
+        "confirm_destructive_action",
+        "locate_device",
+        "quarantine_client",
+        "reconnect_client",
+        "rename_device",
+        "restart_device",
+        "restore_config",
+        "toggle_traffic_route",
+        "toggle_traffic_rule",
+        "trigger_speedtest",
+        "unblock_client",
+    }
+)
+
+
+@pytest.fixture()
+def _all_modules_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register network + protect + access so the gate is tested over every tool."""
+    monkeypatch.setenv("MCP_UNIFI_MODULES_ENABLED", "network,protect,access")
+
+
+def _settings(*, readonly: bool) -> Settings:
+    return Settings(
+        stub_mode=True,
+        log_format="text",
+        mcp_transport="stdio",
+        auth_required=False,
+        readonly=readonly,
+    )
+
+
+def _payload(result: Any) -> Any:
+    return json.loads(result.content[0].text)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: classification is total
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_registered_tool_is_classified(_all_modules_enabled: None) -> None:
+    """The gate is only trustworthy if nothing is unclassified.
+
+    This is the test that blocks CI when someone adds a tool and forgets. It
+    reads the live registration rather than any hand-maintained list.
+    """
+    server = build_server(_settings(readonly=False))
+    tools = await server.list_tools()
+    classified = classified_tools()
+    unclassified = sorted(t.name for t in tools if t.name not in classified)
+    assert unclassified == [], (
+        f"tools with no mutates= declaration: {unclassified}. "
+        f"Add it to their @audited(...) decorator."
+    )
+    assert len(tools) > 100, "sanity: the whole tool surface should be registered here"
+
+
+@pytest.mark.asyncio
+async def test_classification_reaches_the_tool_tags(_all_modules_enabled: None) -> None:
+    """The declaration must survive registration as the tag the middleware reads."""
+    server = build_server(_settings(readonly=False))
+    classified = classified_tools()
+    mismatched = [
+        t.name
+        for t in await server.list_tools()
+        if (MUTATING_TAG in t.tags) is not classified[t.name]
+    ]
+    assert mismatched == []
+
+
+@pytest.mark.asyncio
+async def test_both_read_and_write_tools_exist(_all_modules_enabled: None) -> None:
+    """Guard against a classification bug that collapses everything one way."""
+    tools = await build_server(_settings(readonly=False)).list_tools()
+    mutating = {t.name for t in tools if MUTATING_TAG in t.tags}
+    reads = {t.name for t in tools} - mutating
+    assert len(mutating) > 50
+    assert len(reads) > 50
+
+
+def test_prefix_classifier_would_have_missed_these() -> None:
+    """The 13 tools that make a name-prefix gate unsafe.
+
+    Twelve of them mutate and would have stayed callable in "read-only" mode.
+    ``backup_config`` is the thirteenth: a prefix gate would have missed it
+    too, but in the harmless direction — it is a pure read and is classified
+    as one here. Asserting both directions keeps this test honest about which
+    is which.
+    """
+    classified = classified_tools()
+    missing = NO_PREFIX_MUTATING_TOOLS - set(classified)
+    assert missing == set(), f"unregistered names in the pin list: {sorted(missing)}"
+
+    expected_reads = {"backup_config"}
+    for name in sorted(NO_PREFIX_MUTATING_TOOLS - expected_reads):
+        assert classified[name] is True, f"{name} must be classified as mutating"
+    for name in sorted(expected_reads):
+        assert classified[name] is False, f"{name} must be classified as a read"
+
+
+def test_confirm_destructive_action_is_mutating() -> None:
+    """Called out on its own: it executes a queued delete.
+
+    A read-only mode that still permits this tool lets an agent commit a
+    deletion that was previewed before the mode was turned on.
+    """
+    assert classified_tools()["confirm_destructive_action"] is True
+
+
+def test_unclassified_tool_refuses_to_register() -> None:
+    """Registration fails closed, so an unclassified tool cannot reach a client."""
+    mcp: FastMCP = FastMCP("test")
+
+    @mcp.tool()
+    async def unclassified_tool() -> str:
+        return "{}"
+
+    with pytest.raises(UnclassifiedToolError, match="did not declare"):
+        _tag_new_tools(mcp, module_name="network", existing=set())
+
+
+def test_conflicting_classification_is_rejected() -> None:
+    """One tool name cannot carry two answers."""
+    from mcp_unifi.modules._audit import ToolClassificationConflictError
+
+    @audited("write_gate_conflict_probe", mutates=False)
+    async def probe() -> str:
+        return "{}"
+
+    with pytest.raises(ToolClassificationConflictError):
+
+        @audited("write_gate_conflict_probe", mutates=True)
+        async def probe_again() -> str:
+            return "{}"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: tools/list hides mutating tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_readonly_list_tools_hides_every_mutating_tool(
+    _all_modules_enabled: None,
+) -> None:
+    open_tools = {t.name for t in await build_server(_settings(readonly=False)).list_tools()}
+    readonly_tools = await build_server(_settings(readonly=True)).list_tools()
+
+    assert [t.name for t in readonly_tools if MUTATING_TAG in t.tags] == []
+    hidden = open_tools - {t.name for t in readonly_tools}
+    assert "create_vlan" in hidden
+    assert "confirm_destructive_action" in hidden
+    assert "restore_config" in hidden
+
+
+@pytest.mark.asyncio
+async def test_readonly_list_tools_keeps_read_tools(_all_modules_enabled: None) -> None:
+    names = {t.name for t in await build_server(_settings(readonly=True)).list_tools()}
+    for expected in ("list_networks", "get_site_health", "backup_config", "audit_open_ports"):
+        assert expected in names
+
+
+@pytest.mark.asyncio
+async def test_default_mode_lists_mutating_tools(_all_modules_enabled: None) -> None:
+    """Existing deployments must be untouched when the setting is left off."""
+    names = {t.name for t in await build_server(_settings(readonly=False)).list_tools()}
+    assert "create_vlan" in names
+    assert "confirm_destructive_action" in names
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: tools/call refuses mutating tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_readonly_call_of_a_hidden_tool_is_refused(stub_state: StubState) -> None:
+    """Naming the tool anyway must not work — and must not touch state."""
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    before = len(stub_state.networks)
+
+    result = await server.call_tool(
+        "create_vlan",
+        {"name": "ShouldNotExist", "vlan_id": 99, "subnet": "10.0.99.0/24"},
+    )
+
+    payload = _payload(result)
+    assert "read-only mode" in payload["error"]
+    assert "create_vlan" in payload["error"]
+    assert len(stub_state.networks) == before, "the tool body ran despite the refusal"
+    assert not any(n.get("name") == "ShouldNotExist" for n in stub_state.networks)
+
+
+@pytest.mark.asyncio
+async def test_readonly_refusal_uses_the_standard_error_envelope(
+    stub_settings: Settings,
+) -> None:
+    """A refusal is an error envelope, not a framework exception.
+
+    Callers already parse ``{"error": ..., "stub_mode": ...}`` from every tool
+    in this server. The gate must not make them learn a second failure shape.
+    """
+    server = build_server(_settings(readonly=True))
+    result = await server.call_tool("delete_vlan", {"network_id": "whatever"})
+    payload = _payload(result)
+
+    reference = json.loads(make_err(stub_settings)("some upstream failure"))
+    assert set(payload) == set(reference)
+    assert payload["stub_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_readonly_refusal_names_no_controller_call(stub_state: StubState) -> None:
+    """Every destructive path is refused, including the confirm half."""
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    before = list(stub_state.wlans)
+    result = await server.call_tool("confirm_destructive_action", {"token": "anything"})
+    assert "read-only mode" in _payload(result)["error"]
+    assert stub_state.wlans == before
+
+
+@pytest.mark.asyncio
+async def test_readonly_read_tools_still_work(stub_state: StubState) -> None:
+    """The gate must not be a blunt instrument: reads behave exactly as before."""
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    payload = _payload(await server.call_tool("list_networks", {}))
+    assert isinstance(payload, list)
+    assert len(payload) == len(stub_state.networks)
+    assert "error" not in payload[0]
+
+
+@pytest.mark.asyncio
+async def test_default_mode_still_allows_mutating_calls(stub_state: StubState) -> None:
+    """The whole feature is opt-in; with it off, writes go through."""
+    server = build_server(_settings(readonly=False), stub=stub_state)
+    before = len(stub_state.networks)
+    payload = _payload(
+        await server.call_tool(
+            "create_vlan",
+            {"name": "GateOff", "vlan_id": 77, "subnet": "10.0.77.0/24"},
+        )
+    )
+    assert "error" not in payload
+    assert len(stub_state.networks) == before + 1
+
+
+@pytest.mark.asyncio
+async def test_readonly_refusal_reaches_a_negotiated_client(stub_state: StubState) -> None:
+    """End-to-end over a real MCP session, not just the in-process call path.
+
+    Proves the refusal survives the adaptive-response middleware and arrives
+    as a readable error rather than a transport-level failure.
+    """
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    async with Client(server) as client:
+        listed = {t.name for t in await client.list_tools()}
+        assert "create_vlan" not in listed
+        assert "list_networks" in listed
+
+        result = await client.call_tool(
+            "create_vlan",
+            {"name": "Nope", "vlan_id": 88, "subnet": "10.0.88.0/24"},
+        )
+        assert "read-only mode" in result.structured_content["error"]
+        assert not any(n.get("name") == "Nope" for n in stub_state.networks)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed behavior on an unresolvable tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_tool_is_refused_not_permitted() -> None:
+    """If the middleware cannot resolve a tool's tags, it denies.
+
+    ``fastmcp_context`` is ``None`` here, which is the shape the middleware
+    sees when it cannot reach the registration. Permitting on doubt would turn
+    any lookup failure into an open gate.
+    """
+    from mcp_unifi.scoping import WriteGateMiddleware
+
+    class _Ctx:
+        def __init__(self) -> None:
+            self.message = type("M", (), {"name": "create_vlan"})()
+            self.fastmcp_context = None
+
+    called = False
+
+    async def call_next(_ctx: Any) -> Any:
+        nonlocal called
+        called = True
+        return "SHOULD NOT HAPPEN"
+
+    gate = WriteGateMiddleware(stub_mode=True)
+    result = await gate.on_call_tool(_Ctx(), call_next)  # type: ignore[arg-type]
+    assert called is False
+    assert "read-only mode" in json.loads(result.content[0].text)["error"]
+
+
+# ---------------------------------------------------------------------------
+# Settings surface
+# ---------------------------------------------------------------------------
+
+
+def test_readonly_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MCP_UNIFI_READONLY", raising=False)
+    assert Settings(stub_mode=True, auth_required=False).readonly is False
+
+
+def test_readonly_reads_the_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_UNIFI_READONLY", "true")
+    assert Settings(stub_mode=True, auth_required=False).readonly is True
+
+
+def test_readonly_appears_in_safe_repr() -> None:
+    """Operators need to see the posture in the startup log line."""
+    assert Settings(stub_mode=True, auth_required=False, readonly=True).safe_repr()["readonly"] is (
+        True
+    )

--- a/tests/test_write_gate.py
+++ b/tests/test_write_gate.py
@@ -167,6 +167,21 @@ def test_unclassified_tool_refuses_to_register() -> None:
         _tag_new_tools(mcp, module_name="network", existing=set())
 
 
+def test_unenumerable_tool_list_refuses_to_register(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If tools cannot be enumerated, nothing gets tagged — so refuse to start.
+
+    ``_iter_registered_tools`` reads FastMCP internals and used to degrade to
+    an empty list. Degrading silently would leave every tool untagged, which
+    the write gate would read as "no mutating tools to hide" — a read-only
+    server with the gate wide open.
+    """
+    from mcp_unifi import dispatcher
+
+    monkeypatch.setattr(dispatcher, "_iter_registered_tools", lambda _mcp: [])
+    with pytest.raises(UnclassifiedToolError, match="could not enumerate"):
+        build_server(_settings(readonly=True))
+
+
 def test_conflicting_classification_is_rejected() -> None:
     """One tool name cannot carry two answers."""
     from mcp_unifi.modules._audit import ToolClassificationConflictError


### PR DESCRIPTION
## What

Adds `MCP_UNIFI_READONLY`. When on, every tool that changes state is hidden from `tools/list` **and** refused on `tools/call`. Default off, so existing deployments are unchanged.

This is defense in depth on top of a read-only UniFi API key, not a replacement for one. The key decides what the controller will accept; this decides what the server is willing to attempt.

## Why both halves

Hiding a tool only removes the suggestion. A client that hard-codes a tool name, replays a cached manifest, or guesses would still reach the tool body. The call-time refusal is the control; the listing filter keeps a model from trying. Both are tested, including that the underlying state does not move on a refused call.

A refusal returns the standard `{"error": ..., "stub_mode": ...}` envelope rather than raising a `ToolError`, matching how every other failure in this server surfaces (same reasoning as `resolve_backend`). Callers need no second failure path.

## Classification mechanism

Every tool declares its own classification on the decorator it already carried:

```python
@mcp.tool()
@audited("list_networks", mutates=False)
async def list_networks(...) -> str: ...
```

`mutates` is a **required** keyword argument. That makes the gate fail closed at import: a tool added without it raises `TypeError` and the server does not start. `register_modules` additionally raises `UnclassifiedToolError` when a registered tool has no declaration, when a tool exposes no tags set, or when the tool list cannot be enumerated at all — tagging used to be best-effort, and both this gate and per-client scoping depend on those tags. `tests/test_write_gate.py::test_every_registered_tool_is_classified` enumerates the live registration and fails on the same condition, so CI blocks before a deploy can.

Chose this over a central name→bool set because the declaration sits next to the tool body and its `Side effects:` docstring, so classification and implementation land in the same diff and the same review.

## Why not name prefixes

Classifying by `create_`/`update_`/`delete_`/`set_`/`provision_`/`apply_`/`reboot` leaves **twelve mutating tools callable**:

`confirm_destructive_action`, `restore_config`, `block_client`, `unblock_client`, `quarantine_client`, `reconnect_client`, `restart_device`, `rename_device`, `locate_device`, `toggle_traffic_rule`, `toggle_traffic_route`, `trigger_speedtest`

The first is disqualifying on its own: `confirm_destructive_action` is the tool that *executes* a queued delete. A prefix gate would have shipped a "read-only" server that still commits deletions. That list is pinned in `test_prefix_classifier_would_have_missed_these` so the shortcut cannot quietly come back.

## Judgment calls

Each is recorded in a comment beside the classification so it is not re-litigated:

| Tool | Call | Reasoning |
|---|---|---|
| `trigger_speedtest` | mutates | Changes no config, but makes the gateway saturate the WAN for 30-60s on demand. Read-only must mean the server cannot make hardware do work. `get_speedtest_results` stays available. |
| `locate_device` | mutates | Flashes a physical LED until something turns it off. Changing what the hardware does in the room is not a read. |
| `rename_device` | mutates | Cosmetic, but persisted, and it is the label every other tool's output shows. |
| `backup_config` | read | A fan-out of GETs returned to the caller; writes nothing to the controller. Taking a backup is exactly what you want to still be able to do in read-only mode. |
| `get_console_health` / `get_console_firmware` | read | May POST a login, but authenticating is how the server reads UniFi OS at all. Classifying login as mutating would cost read-only mode the one tool that answers when Network is down. |
| every `delete_*` | mutates | Including the preview phase. Preview-then-confirm is an interlock against mistakes, not an access control. |

Totals: 134 registered tools, 62 mutating, 72 read.

## Tests

`tests/test_write_gate.py`, 20 cases across three layers (classification, visibility, invocation) plus the settings surface. Verified red first:

- Middleware not installed → 4 enforcement tests fail (`..._hides_every_mutating_tool`, `..._call_of_a_hidden_tool_is_refused`, `..._refusal_names_no_controller_call`, `..._reaches_a_negotiated_client`).
- `confirm_destructive_action` flipped to `mutates=False` → 4 fail, including both classification pins.

Full suite: 1066 passed, 89% branch coverage (gate is 80%). ruff, ruff-format, mypy strict, and the tool-manifest drift check all clean.

## Also included

- Helm chart: added `readOnly: false` value plus the env block. Without it a chart user could not enable the mode at all, which would have left the feature half-shipped on that distribution path. Additive and non-breaking.
- `.env.example`, README (Design + Configuration), `docs/site` security guide and configuration reference.
- `## [Unreleased]` CHANGELOG entry. No version bump — release is Pete's.

## Out of scope

Out-of-band delete approval via MCP elicitation, compile-time module exclusion (already done), Integration API migration, `verify_ssl` defaults.