### PR TITLE
fix(backup): restore warning now names networks, not just WLANs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-client scoping and read-only mode both depend on those tags, so a
   silent no-op is no longer an acceptable outcome.
 
+### Fixed
+
+- **`restore_config`'s stripped-secrets warning named only WLANs.** 0.20.0
+  extended the force-disable to networks, so a restored site-to-site VPN comes
+  back `enabled=false` because its pre-shared key is not in the envelope. The
+  runtime warning still read "WLAN passphrases were stripped … restored WLANs
+  will be force-disabled", so the operator most affected by the change — the
+  one restoring a tunnel — was told only about WiFi. The warning now names
+  both resource types and says why. The behavior was already correct; only the
+  explanation was wrong, which is the harder kind of wrong to notice.
+
 ## [0.20.0] - 2026-08-12
 
 ### Fixed

--- a/src/mcp_unifi/modules/network/backup.py
+++ b/src/mcp_unifi/modules/network/backup.py
@@ -554,9 +554,10 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
         secrets_stripped = bool(envelope.get("secrets_stripped"))
         if secrets_stripped:
             warnings.append(
-                "WLAN passphrases were stripped from backup; restored WLANs "
-                "will be force-disabled. Reset each passphrase and re-enable "
-                "manually."
+                "Secrets were stripped from this backup. Any restored WLAN or "
+                "network carrying a stripped secret will be force-disabled — "
+                "that includes VPN networks, whose pre-shared key is not in "
+                "the envelope. Reset each secret and re-enable manually."
             )
 
         try:

--- a/tests/network/test_backup_restore.py
+++ b/tests/network/test_backup_restore.py
@@ -434,7 +434,15 @@ async def test_stripped_secrets_force_disables_restored_wlans(
 
     result = await _call(fresh_server, "restore_config", {"backup_json": backup_json})
     assert "error" not in result
-    assert any("passphrase" in w.lower() and "disabled" in w.lower() for w in result["warnings"])
+    # The warning must name networks as well as WLANs. 0.20.0 extended the
+    # force-disable to networks (a restored VPN comes back disabled because
+    # its PSK is not in the envelope) while this text still spoke only of
+    # WLAN passphrases, so an operator restoring a site-to-site tunnel was
+    # told nothing about the thing that had actually just been turned off.
+    warning = next(w for w in result["warnings"] if "disabled" in w.lower())
+    assert "wlan" in warning.lower()
+    assert "network" in warning.lower()
+    assert "secret" in warning.lower()
     # The recreated WLAN must be disabled.
     assert len(fresh_state.wlans) == 1
     assert fresh_state.wlans[0]["enabled"] is False


### PR DESCRIPTION
Follow-up to the 0.20.0 hardening, found while checking what an existing user would actually experience after upgrading.

0.20.0 extended the stripped-secret force-disable from WLANs to networks. A restored site-to-site VPN now comes back `enabled=false`, because its pre-shared key is not in the backup envelope. That behavior is correct and intended.

The runtime warning was not updated alongside it:

> WLAN passphrases were stripped from backup; restored WLANs will be force-disabled. Reset each passphrase and re-enable manually.

So the operator most affected by the change, the one restoring a tunnel, was told only about WiFi. The behavior was right and the explanation was wrong, which is the harder kind of wrong to catch, because nothing fails.

## Test

The existing test asserted `"passphrase" in w.lower()`, so it would have passed against any wording that happened to keep that single word. It now asserts the warning names both resource types and the reason. Verified red against the old text before the fix.