### PR TITLE
docs(site): make the changelog page a pointer instead of a stale mirror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ audit.jsonl
 
 # uv side-effect lockfile — project uses requirements*.lock as source of truth
 uv.lock
+
+# Claude Code agent worktrees and local session state (never part of the repo).
+.claude/

--- a/docs/site/src/content/docs/changelog.md
+++ b/docs/site/src/content/docs/changelog.md
@@ -1,92 +1,21 @@
 ---
 draft: false
 title: Changelog
-description: Notable changes across mcp-unifi releases.
+description: Where to find the authoritative changelog and release notes for mcp-unifi.
 ---
 
-The full, authoritative changelog lives in [`CHANGELOG.md`](https://github.com/pete-builds/mcp-unifi/blob/main/CHANGELOG.md) in the repo. This page mirrors the high points so you can scan recent releases without leaving the docs.
+The changelog lives in the repository, not here.
 
-The project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+- **[CHANGELOG.md](https://github.com/pete-builds/mcp-unifi/blob/main/CHANGELOG.md)** — every release, in full, in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+- **[Releases](https://github.com/pete-builds/mcp-unifi/releases)** — the same notes per tag, alongside the signed image, the CycloneDX SBOM, and the `.dxt` bundle for that version.
+- **[Security advisories](https://github.com/pete-builds/mcp-unifi/security/advisories)** — anything with a security impact is published here as well as in the changelog.
 
-## [0.5.0-rc.2] — 2026-05-14
+The project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Phase 2 polish on top of rc.1: drift audit, backup/restore, and LLM-readable tool descriptions across all 46 tools. Existing tool behavior unchanged; signatures unchanged.
-
-**Added**
-
-- `audit_network_drift`: compare current controller state to a YAML spec, return a structured diff (missing / extra / drift). Matches resources by name (case-insensitive).
-- `backup_config`: snapshot controller state into a versioned JSON envelope (`schema=1`). WLAN passphrases stripped to a sentinel; envelope flagged `secrets_stripped: true`.
-- `restore_config`: compute an action plan from a backup envelope and apply it with rollback on partial failure. Restored WLANs from a secrets-stripped envelope are recreated with `enabled=False`.
-- **Tool description rewrites** across all 46 tools: verb-first one-line purpose, `Side effects:` bullets, `dry_run` hint on destructive tools, `Rollback:` contract on composites, an `Example:` line with realistic args, and per-parameter docstrings on `controller` and `dry_run`.
-
-**Tests**
-
-- 383 tests passing (+37 from rc.1). 90% coverage maintained.
-- New: `tests/network/test_drift.py`, `tests/network/test_backup_restore.py` (includes a Hypothesis property test for backup-mutate-restore convergence), `tests/test_tool_descriptions.py`.
-
-## [0.5.0-rc.1] — 2026-05-14
-
-Phase 1: multi-site, dry-run, and audit log. Single-controller users running v0.4.x see no behavioral change in real mode; legacy `UNIFI_HOST` + `UNIFI_API_KEY` env vars still auto-promote to a one-controller config.
-
-**Added**
-
-- **Multi-site config**: `Settings.controllers: list[ControllerConfig]`. Every tool accepts an optional `controller: str = "default"` parameter that selects which controller the call routes to. Optional `MCP_UNIFI_CONTROLLERS_FILE` env var points at a YAML file for more than one controller.
-- **Backward compat**: existing single-controller env vars auto-promote to `controllers=[ControllerConfig(name="default", ...)]`. No config change required for v0.4.x users.
-- **`SecretStr` on `api_key`**: controller credentials are wrapped in Pydantic's `SecretStr`. `repr()` and structured logging never echo the raw key.
-- **Module dispatcher**: `MCP_UNIFI_MODULES_ENABLED` env (default `"network"`) controls which modules register tools at startup.
-- **Network module split**: the single 1000-line `server.py` was split into 10 files under `src/mcp_unifi/modules/network/`. No behavior change.
-- **`Backend` protocol**: `StubBackend` and `RealBackend` share one async surface. Tools call `backend.X()` instead of branching on `settings.stub_mode`.
-- **Dry-run on 27 destructive tools**: `dry_run: bool = False` returns the predicted change set without writing. Composite dry-runs return the full graph with placeholder IDs.
-- **Audit log substrate**: `src/mcp_unifi/audit.py` writes one JSONL record per call. Configurable sink: file (default), stdout, syslog. Args containing `passphrase` / `api_key` / `password` / `secret` are scrubbed before emission.
-- **`@audited` decorator**: wraps every tool registration so emit happens uniformly.
-- **`mcp-unifi-replay` CLI**: re-issues calls from a JSONL audit log. Useful for migrations and reproducing test scenarios.
-- **Hypothesis property tests**: rollback correctness on the four destructive composites. Hypothesis injects a failure at any sub-step and asserts post-failure stub state is byte-identical to the pre-call snapshot.
-- **Multi-site test fixtures**: `two_controller_settings`, `two_controller_states`, `multi_site_server` in `tests/network/conftest.py`.
-
-**Changed**
-
-- Test layout: `tests/test_tools.py` (~3000 lines) split into `tests/network/` per source module. Test count: 224 → 346. Coverage: 91%.
-
-## [0.4.1] — 2026-05-14
-
-**Fixed**
-
-- `create_port_forward` and `create_port_profile` no longer mask the underlying `UniFiError` with `"Attempt to overwrite 'name' in LogRecord"`. Renamed log `extra` keys to `forward_name` / `profile_name`.
-
-## [0.4.0] — 2026-05-10
-
-**Added**
-
-- **stdio transport** alongside Streamable HTTP. Selected via the new `MCP_TRANSPORT` env var (default `streamable-http` for back-compat).
-- stdio install path: `uvx --from git+https://github.com/pete-builds/mcp-unifi mcp-unifi`. Installs straight from the repo; pin a release with `@v0.4.0`.
-
-**Changed**
-
-- Logging now writes to **stderr** instead of stdout (required for stdio transport; stdout owns the JSON-RPC framing).
-
-## [0.3.0] — 2026-05-09
-
-**Added — 26 new tools across four tiers**
-
-- **Tier 1 (CRUD gap fills)**: `update_firewall_rule`, `create_port_profile`, `update_port_profile`, `delete_port_profile`.
-- **Tier 2 (high-frequency ops)**: `block_client`, `unblock_client`, `reconnect_client`, `set_port_state`, `restart_device`, `locate_device`, `list_dhcp_leases`, `create_static_dhcp_lease`, `delete_static_dhcp_lease`, `list_port_forwards`, `create_port_forward`, `update_port_forward`, `delete_port_forward`.
-- **Tier 3 (observability)**: `get_site_health`, `get_wan_status`, `list_events`, `list_alarms`, `trigger_speedtest`, `get_speedtest_results`, `list_top_talkers`.
-- **Tier 4 (composites with rollback)**: `provision_homelab_service`, `quarantine_client`, `create_guest_network`, `audit_open_ports`.
-
-Tool count: 15 → 41. Test count: 126 → 224. Coverage: 90%.
-
-## [0.2.0] — 2026-05-02
-
-**Added**
-
-- `delete_wlan`, `update_wlan`, `delete_firewall_rule`, `list_clients` MCP tools.
-
-Tool count: 11 → 15. Test count: 101 → 126.
-
-**Changed**
-
-- Base image bumped to `python:3.14-slim` (digest-pinned).
-
-## [0.1.0] — 2026-05-01
-
-Initial public release. Eleven MCP tools, hardened Docker image (non-root, read-only fs, hash-pinned deps, Trivy-scanned), stub mode for hardware-free development, real mode for UCG-Fiber / UDM Pro / other UniFi OS gateways via the local API key.
+:::note[Why this page is a pointer]
+It used to mirror "the high points" of each release. Mirrors need feeding, this
+one did not get fed, and it sat fifteen releases behind while still reading as
+current — which is worse than having no page at all, because a stale changelog
+looks like an accurate one. A link cannot go out of date, so that is what this
+is now.
+:::

--- a/tests/test_docs_drift.py
+++ b/tests/test_docs_drift.py
@@ -28,10 +28,6 @@ MANIFEST_JSON_PATH = REPO_ROOT / "docs" / "site" / "src" / "data" / "tool-manife
 HISTORICAL_ALLOWLIST: frozenset[Path] = frozenset(
     {
         REPO_ROOT / "CHANGELOG.md",
-        # The docs site ships its own changelog page rendered from a copy of
-        # CHANGELOG.md; per-release entries there quote counts current at
-        # the time and should not be back-edited.
-        REPO_ROOT / "docs" / "site" / "src" / "content" / "docs" / "changelog.md",
         REPO_ROOT / "docs" / "v0.10-access-module.md",
     }
 )


### PR DESCRIPTION
Found while checking what a current user actually sees after the 0.20.0 upgrade.

The docs site has a **Changelog** entry in its nav. The page said it mirrored "the high points so you can scan recent releases without leaving the docs", and its most recent entry was `0.5.0-rc.2` from 2026-05-14. The project has since shipped through 0.20.0.

A stale changelog is worse than no changelog. It reads as authoritative, so a visitor concludes nothing has happened in fifteen releases rather than concluding the page is broken.

## The reason it went unnoticed

It was in `HISTORICAL_ALLOWLIST` in `tests/test_docs_drift.py`, with this rationale:

> per-release entries there quote counts current at the time and should not be back-edited

That is correct for `CHANGELOG.md`, which is append-only and therefore maintains itself. Applied to a hand-curated mirror it did the opposite: it guaranteed nothing in CI would ever notice the page had stopped being updated.

## Change

The page is now a pointer to `CHANGELOG.md`, the releases page, and the security advisories, with a short note explaining why it is a pointer so nobody helpfully turns it back into a mirror. Removed from the drift allowlist: it carries no version numbers now, so it passes, and if a version list is ever reintroduced the drift test will hold it to the same standard as every other user-facing doc.

Nav link and page URL are unchanged.

## Not changed

`SESSION-RESUME.md` is also stale (v0.15.3), but it is gitignored and local-only, so it never reaches a user. Left alone.