### PR TITLE
feat(audit): record refused calls with a denied_by field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preview-then-confirm is an interlock against mistakes, not an access
   control.
 
+- **Refused calls are recorded in the audit log.** A denied mutation attempt
+  now writes its own line to `audit.jsonl`, carrying a new `denied_by` field:
+  `"readonly"` when the write gate refused it, `"scope"` when per-client
+  module scoping did. `denied_by` is `null` on every call that was actually
+  dispatched, so `jq 'select(.denied_by)' audit.jsonl` answers "what did my
+  agent try to do that it was not allowed to do" in one pass.
+
+  It is a separate field rather than a convention on the error message
+  because `success: false` already means three different things in this log —
+  the tool raised, the controller returned an error, or the call was never
+  made — and only the third is a security event. The record carries the
+  timestamp, tool name, attempted arguments, and the authenticated
+  `client_id` where the transport has one.
+
+  Refusals are emitted above the `@audited` decorator (the gate turns the
+  call away before it reaches a tool body), but they go through the same
+  `AuditLog.emit` path, so attempted arguments are scrubbed exactly like a
+  dispatched call's: a refused `create_wlan` does not write the caller's
+  passphrase to disk. An audit-sink failure is logged and swallowed rather
+  than surfaced, so it can never turn a clean refusal into a transport error.
+
 ### Changed
 
+- `mcp-unifi-replay` now skips events with `denied_by` set instead of
+  re-issuing them. Those calls were refused and never dispatched; replaying
+  one against a live controller would perform the action the operator's own
+  policy denied. They are reported as skipped, alongside the existing
+  off-target-controller skip.
 - `register_modules` now raises `UnclassifiedToolError` when a registered tool
   has no `mutates` declaration, when a tool exposes no tags set, or when the
   tool list cannot be enumerated at all. Tagging used to be best-effort;

--- a/docs/site/src/content/docs/guides/dry-run-audit.md
+++ b/docs/site/src/content/docs/guides/dry-run-audit.md
@@ -83,6 +83,25 @@ Field notes:
 - **`latency_ms`**: end-to-end tool latency including controller round-trip in real mode.
 - **`result_shape`**: structured summary (success/error kind, returned IDs) — not the full response body.
 
+### Refused calls
+
+A call that a control turned away never reaches a tool body, so it would otherwise leave no trace in the log at all. Those attempts are recorded too, with a `denied_by` field naming the control that refused them:
+
+| `denied_by` | Refused by | Fix if it was legitimate |
+|---|---|---|
+| `"readonly"` | The read-only write gate (`MCP_UNIFI_READONLY=true`) | Turn the posture off, or run the change by hand. |
+| `"scope"` | Per-client module scoping (`MCP_UNIFI_AUTH_TOKENS`) | Widen that client's module allowlist. |
+| `null` | Nothing — the call was dispatched | n/a |
+
+```bash
+# What did my agent try to do that it was not allowed to do?
+jq -c 'select(.denied_by) | {ts, client_id, tool, denied_by}' audit.jsonl
+```
+
+Refused records carry `success: false` and `result: null`, and their `args` are scrubbed on exactly the same path as a dispatched call — a refused `create_wlan` does not write the passphrase the caller supplied.
+
+Don't key off `success` alone: it is already `false` when a tool raised or the controller returned an error. `denied_by` is the only field that distinguishes "the call was never made" from "the call was made and failed". `mcp-unifi-replay` reads it too, and skips refused events rather than re-issuing them.
+
 ### Configure the sink
 
 | Env var | Default | What it does |

--- a/src/mcp_unifi/audit.py
+++ b/src/mcp_unifi/audit.py
@@ -79,6 +79,19 @@ class AuditEvent:
     #: Replay tools tolerate older logs missing this field via the dataclass
     #: default, so schema stays at "1".
     client_id: str | None = None
+    #: Which control refused this call before it ever reached the tool body
+    #: (v0.21.0+): ``"readonly"`` for the write gate, ``"scope"`` for
+    #: per-client module scoping. ``None`` on every call that was actually
+    #: dispatched, so ``jq 'select(.denied_by)'`` isolates exactly the
+    #: attempts that were blocked.
+    #:
+    #: This is a separate field rather than a convention on ``error``
+    #: because ``success: false`` already means three different things in
+    #: this log — the tool raised, the controller returned an error, or the
+    #: call was never made. Only the third is a security event, and only
+    #: this field distinguishes it without parsing prose. Replay reads it
+    #: to skip refused calls instead of re-issuing them.
+    denied_by: str | None = None
     # Schema version. Bump when the envelope shape changes so replay can
     # reject incompatible logs cleanly.
     schema: str = field(default="1")
@@ -223,8 +236,9 @@ class AuditLog:
         latency_ms: float,
         error: str | None = None,
         client_id: str | None = None,
+        denied_by: str | None = None,
     ) -> AuditEvent:
-        """Record a single tool invocation.
+        """Record a single tool invocation, or a refusal to make one.
 
         Args are scrubbed before serialisation; the live arg dict the caller
         passed is not mutated. The returned :class:`AuditEvent` is convenient
@@ -244,6 +258,7 @@ class AuditLog:
             latency_ms=round(latency_ms, 3),
             error=error,
             client_id=client_id,
+            denied_by=denied_by,
         )
         async with self._lock:
             try:
@@ -348,6 +363,9 @@ def parse_jsonl(lines: Iterable[str]) -> list[AuditEvent]:
                     error=payload.get("error"),
                     schema=str(payload.get("schema", "1")),
                     client_id=payload.get("client_id"),
+                    # Absent in logs written before v0.21.0; a missing field
+                    # correctly reads as "this call was dispatched".
+                    denied_by=payload.get("denied_by"),
                 )
             )
         except KeyError as exc:

--- a/src/mcp_unifi/cli/replay.py
+++ b/src/mcp_unifi/cli/replay.py
@@ -107,6 +107,22 @@ async def replay_events(
     srv = server if server is not None else _build_server(stub_mode=stub_mode)
     results: list[ReplayResult] = []
     for event in events:
+        if event.denied_by:
+            # A refused call was never made. The write gate and the scope
+            # gate both write their refusals into this log, and re-issuing
+            # one here would take the exact action the operator's own policy
+            # denied — the log would become a way to launder a denial.
+            results.append(
+                ReplayResult(
+                    tool=event.tool,
+                    controller=event.controller,
+                    success=False,
+                    error=None,
+                    skipped=True,
+                    skip_reason=f"refused at capture time by {event.denied_by}; never dispatched",
+                )
+            )
+            continue
         if (
             not stub_mode
             and target_controller is not None

--- a/src/mcp_unifi/scoping.py
+++ b/src/mcp_unifi/scoping.py
@@ -55,6 +55,8 @@ from fastmcp.server.middleware.middleware import (
 from fastmcp.tools.tool import Tool, ToolResult
 from mcp import types as mt
 
+from mcp_unifi import audit
+
 logger = logging.getLogger("mcp_unifi.scoping")
 
 WILDCARD = "*"
@@ -64,6 +66,14 @@ WILDCARD = "*"
 #: set as the module tags, so :func:`_tool_modules` filters it back out before
 #: any module-scope comparison.
 MUTATING_TAG = "mutating"
+
+#: Values written to :attr:`mcp_unifi.audit.AuditEvent.denied_by` so an
+#: operator can tell the two controls apart in one ``jq`` pass. Read-only mode
+#: is a property of the server; scope is a property of the caller, and the
+#: response to each is different — one is "turn the posture off", the other is
+#: "widen this client's token".
+DENIED_BY_READONLY = "readonly"
+DENIED_BY_SCOPE = "scope"
 
 
 class ScopeMiddleware(Middleware):
@@ -105,8 +115,21 @@ class ScopeMiddleware(Middleware):
             if not tool_modules & allowed:
                 # Never disclose which modules exist — a scoped client
                 # shouldn't be able to enumerate tools it can't see by
-                # brute-forcing names and reading the denial message.
-                raise ToolError(f"Tool {tool_name!r} is not available to this client.")
+                # brute-forcing names and reading the denial message. The
+                # audit record is the opposite side of that wall: the
+                # operator reading the log is entitled to the detail the
+                # caller is not.
+                message = f"Tool {tool_name!r} is not available to this client."
+                await _record_refusal(
+                    context,
+                    tool_name=tool_name,
+                    denied_by=DENIED_BY_SCOPE,
+                    error=(
+                        f"{message} Refused by per-client module scoping "
+                        f"(MCP_UNIFI_AUTH_TOKENS). No call was made to the controller."
+                    ),
+                )
+                raise ToolError(message)
         return await call_next(context)
 
     def _allowed_modules_for_current_request(self) -> set[str]:
@@ -188,6 +211,66 @@ async def _resolve_tool_modules(
     return set() if tool is None else _tool_modules(tool)
 
 
+def _attempted_args(context: MiddlewareContext[mt.CallToolRequestParams]) -> dict[str, Any]:
+    """Return the arguments the caller tried to use, as an audit-shaped dict.
+
+    A non-dict ``arguments`` payload is wrapped rather than dropped: the point
+    of a refusal record is what was attempted, and "the caller sent something
+    malformed" is itself worth keeping. Never returns the caller's object by
+    reference, so scrubbing downstream cannot mutate live request state.
+    """
+    arguments = getattr(context.message, "arguments", None)
+    if isinstance(arguments, dict):
+        return dict(arguments)
+    if arguments is None:
+        return {}
+    return {"_arguments": arguments}
+
+
+async def _record_refusal(
+    context: MiddlewareContext[mt.CallToolRequestParams],
+    *,
+    tool_name: str,
+    denied_by: str,
+    error: str,
+) -> None:
+    """Write a refused call into the audit log.
+
+    The refusal happens above the ``@audited`` decorator, so nothing else in
+    the stack will record it — and a denied mutation attempt is exactly the
+    line an operator reviewing an agent wants to find. The record reuses
+    :meth:`mcp_unifi.audit.AuditLog.emit`, which means the attempted arguments
+    run through the same scrubber as a dispatched call: a refused
+    ``create_wlan`` still arrives carrying the caller's passphrase, and the
+    audit log is a persistent sink like any other.
+
+    ``latency_ms`` is 0.0 rather than a measured value, because no work was
+    done; the gate decided from a tag it already had.
+
+    Failures are swallowed. An audit outage must not convert a clean refusal
+    envelope into a transport-level error — the caller would learn less, not
+    more, and the control itself would appear to have failed open.
+    """
+    try:
+        args = _attempted_args(context)
+        await audit.get_audit_log().emit(
+            controller=str(args.get("controller", "default")),
+            tool=tool_name,
+            args=args,
+            result=None,
+            success=False,
+            latency_ms=0.0,
+            error=error,
+            client_id=_current_client_id(),
+            denied_by=denied_by,
+        )
+    except Exception:  # pragma: no cover - defensive only
+        logger.exception(
+            "failed to record a refused tool call in the audit log",
+            extra={"tool": tool_name, "denied_by": denied_by},
+        )
+
+
 class WriteGateMiddleware(Middleware):
     """Hide and refuse every mutating tool while ``MCP_UNIFI_READONLY`` is on.
 
@@ -246,23 +329,43 @@ class WriteGateMiddleware(Middleware):
                     "resolved": tool is not None,
                 },
             )
-            return self._refusal(tool_name)
+            message = self._refusal_message(tool_name)
+            # The warning above is diagnostic and rotates away with the
+            # container logs. The audit record is the evidence surface, and
+            # "the agent tried to delete a VLAN and was refused" belongs
+            # there — a control that keeps no record of what it denied is
+            # only half a control.
+            await _record_refusal(
+                context,
+                tool_name=tool_name,
+                denied_by=DENIED_BY_READONLY,
+                error=message,
+            )
+            return self._refusal(message)
         return await call_next(context)
 
-    def _refusal(self, tool_name: str) -> ToolResult:
+    @staticmethod
+    def _refusal_message(tool_name: str) -> str:
+        return (
+            f"{tool_name} changes state and this server is running in "
+            f"read-only mode (MCP_UNIFI_READONLY=true). No call was made "
+            f"to the controller. Read tools are unaffected."
+        )
+
+    def _refusal(self, message: str) -> ToolResult:
         payload = json.dumps(
-            {
-                "error": (
-                    f"{tool_name} changes state and this server is running in "
-                    f"read-only mode (MCP_UNIFI_READONLY=true). No call was made "
-                    f"to the controller. Read tools are unaffected."
-                ),
-                "stub_mode": self._stub_mode,
-            },
+            {"error": message, "stub_mode": self._stub_mode},
             indent=2,
             default=str,
         )
         return ToolResult(content=[mt.TextContent(type="text", text=payload)])
 
 
-__all__ = ["MUTATING_TAG", "WILDCARD", "ScopeMiddleware", "WriteGateMiddleware"]
+__all__ = [
+    "DENIED_BY_READONLY",
+    "DENIED_BY_SCOPE",
+    "MUTATING_TAG",
+    "WILDCARD",
+    "ScopeMiddleware",
+    "WriteGateMiddleware",
+]

--- a/tests/test_replay_cli.py
+++ b/tests/test_replay_cli.py
@@ -88,6 +88,52 @@ async def test_replay_real_mode_filters_by_controller() -> None:
     assert [c[0] for c in server.calls] == ["list_devices"]
 
 
+async def test_replay_skips_refused_events() -> None:
+    """A refused call was never made; replaying it would make it for real.
+
+    The write gate and the scope gate now write their refusals into the same
+    log replay consumes. Re-issuing one against a live controller would take
+    an action the operator's own policy denied, so denied events are skipped
+    the same way an off-target controller is.
+    """
+    server = _StubServer()
+    denied = _event("delete_vlan", network_id="x")
+    denied.success = False
+    denied.denied_by = "readonly"
+    results = await replay_mod.replay_events(
+        [_event("list_devices"), denied],
+        stub_mode=True,
+        target_controller=None,
+        i_mean_it=False,
+        server=server,
+    )
+    assert results[1].skipped is True
+    assert "readonly" in (results[1].skip_reason or "")
+    assert [c[0] for c in server.calls] == ["list_devices"]
+
+
+def test_parse_jsonl_round_trips_denied_by(tmp_path: Path) -> None:
+    """Replay must read the new field, and tolerate logs written without it."""
+    from mcp_unifi.audit import parse_jsonl
+
+    log = tmp_path / "audit.jsonl"
+    old = {
+        "ts": "2026-05-14T00:00:00.000Z",
+        "controller": "default",
+        "tool": "list_devices",
+        "args": {},
+        "result": None,
+        "success": True,
+        "latency_ms": 1.0,
+    }
+    new = dict(old, tool="delete_vlan", success=False, denied_by="scope")
+    log.write_text(json.dumps(old) + "\n" + json.dumps(new) + "\n")
+
+    events = parse_jsonl(log.read_text().splitlines())
+    assert events[0].denied_by is None
+    assert events[1].denied_by == "scope"
+
+
 async def test_replay_captures_per_event_failures() -> None:
     server = _StubServer(fail_on={"delete_vlan"})
     events = [_event("list_devices"), _event("delete_vlan", network_id="x")]

--- a/tests/test_scoping.py
+++ b/tests/test_scoping.py
@@ -20,14 +20,17 @@ the middleware itself and hitting real HTTP would just add flakiness.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from fastmcp.exceptions import ToolError
 
+from mcp_unifi.audit import REDACTED, AuditLog, FileSink, set_audit_log
 from mcp_unifi.config import Settings
-from mcp_unifi.scoping import WILDCARD, ScopeMiddleware
+from mcp_unifi.scoping import DENIED_BY_SCOPE, WILDCARD, ScopeMiddleware
 from mcp_unifi.server import build_server
 
 # ---------------------------------------------------------------------------
@@ -240,8 +243,13 @@ class _StubListContext:
 class _StubCallContext:
     """MiddlewareContext stand-in for the on_call_tool path."""
 
-    def __init__(self, tool_name: str, tool_lookup: dict[str, _StubTool]) -> None:
-        self.message = type("_Msg", (), {"name": tool_name})()
+    def __init__(
+        self,
+        tool_name: str,
+        tool_lookup: dict[str, _StubTool],
+        arguments: dict[str, Any] | None = None,
+    ) -> None:
+        self.message = type("_Msg", (), {"name": tool_name, "arguments": arguments or {}})()
 
         class _StubFastmcp:
             async def get_tool(_self, name: str) -> _StubTool:
@@ -468,3 +476,92 @@ def test_scope_middleware_installed_when_any_client_is_scoped() -> None:
     )
     server = build_server(settings)
     assert "ScopeMiddleware" in _middleware_types(server)
+
+
+# ---------------------------------------------------------------------------
+# ScopeMiddleware: refusals land in the audit log
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def audit_log_path(tmp_path: Path) -> Path:
+    """Pin the audit singleton at a per-test file sink and return its path."""
+    path = tmp_path / "scope-refusals.jsonl"
+    set_audit_log(AuditLog(sink=FileSink(path)))
+    return path
+
+
+def _events(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_scope_denial_writes_an_audit_event(audit_log_path: Path) -> None:
+    """Scoping is the sibling control and had the same blind spot.
+
+    An operator reviewing an agent wants one query, not two, for "what was
+    this client refused" — so the record carries the same envelope with a
+    different ``denied_by`` value.
+    """
+    mw = ScopeMiddleware(client_scopes={"readonly": {"protect"}})
+    tools = {t.name: t for t in _all_tools()}
+
+    async def call_next(ctx: Any) -> str:
+        pytest.fail("call_next must not run for a scope-denied tool")
+        return "unreachable"
+
+    with (
+        patch("mcp_unifi.scoping._current_client_id", return_value="readonly"),
+        pytest.raises(ToolError),
+    ):
+        await mw.on_call_tool(_StubCallContext("delete_vlan", tools), call_next)
+
+    events = _events(audit_log_path)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["tool"] == "delete_vlan"
+    assert ev["denied_by"] == DENIED_BY_SCOPE
+    assert ev["client_id"] == "readonly"
+    assert ev["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_scope_denial_scrubs_the_attempted_arguments(audit_log_path: Path) -> None:
+    """Same redaction discipline as every other emitter on this path."""
+    mw = ScopeMiddleware(client_scopes={"readonly": {"protect"}})
+    tools = {t.name: t for t in _all_tools()}
+    secret = "scope-denied-but-still-a-secret"
+
+    async def call_next(ctx: Any) -> str:
+        return "unreachable"
+
+    with (
+        patch("mcp_unifi.scoping._current_client_id", return_value="readonly"),
+        pytest.raises(ToolError),
+    ):
+        await mw.on_call_tool(
+            _StubCallContext("delete_vlan", tools, {"passphrase": secret, "vlan_id": 7}),
+            call_next,
+        )
+
+    assert secret not in audit_log_path.read_text()
+    ev = _events(audit_log_path)[0]
+    assert ev["args"]["passphrase"] == REDACTED
+    assert ev["args"]["vlan_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_scope_permitted_call_writes_no_refusal_event(audit_log_path: Path) -> None:
+    """An in-scope call is dispatched; the middleware annotates nothing."""
+    mw = ScopeMiddleware(client_scopes={"readonly": {"protect"}})
+    tools = {t.name: t for t in _all_tools()}
+
+    async def call_next(ctx: Any) -> str:
+        return "ok"
+
+    with patch("mcp_unifi.scoping._current_client_id", return_value="readonly"):
+        assert await mw.on_call_tool(_StubCallContext("list_cameras", tools), call_next) == "ok"
+
+    assert _events(audit_log_path) == []

--- a/tests/test_write_gate.py
+++ b/tests/test_write_gate.py
@@ -26,17 +26,19 @@ still green.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
 from fastmcp import Client, FastMCP
 
+from mcp_unifi.audit import REDACTED, AuditLog, FileSink, set_audit_log
 from mcp_unifi.clients.stubs import StubState
 from mcp_unifi.config import Settings
 from mcp_unifi.dispatcher import UnclassifiedToolError, _tag_new_tools
 from mcp_unifi.modules._audit import audited, classified_tools
 from mcp_unifi.modules.network._common import make_err
-from mcp_unifi.scoping import MUTATING_TAG
+from mcp_unifi.scoping import DENIED_BY_READONLY, MUTATING_TAG
 from mcp_unifi.server import build_server
 
 #: Mutating tools whose names carry none of the write-shaped prefixes a
@@ -359,6 +361,147 @@ async def test_unresolvable_tool_is_refused_not_permitted() -> None:
     result = await gate.on_call_tool(_Ctx(), call_next)  # type: ignore[arg-type]
     assert called is False
     assert "read-only mode" in json.loads(result.content[0].text)["error"]
+
+
+# ---------------------------------------------------------------------------
+# Refusals land in the audit log
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def audit_log_path(tmp_path: Path) -> Path:
+    """Pin the audit singleton at a per-test file sink and return its path."""
+    path = tmp_path / "refusals.jsonl"
+    set_audit_log(AuditLog(sink=FileSink(path)))
+    return path
+
+
+def _events(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_refused_call_writes_an_audit_event(
+    stub_state: StubState, audit_log_path: Path
+) -> None:
+    """A control that leaves no record of what it denied is half a control.
+
+    The refusal happens above the ``@audited`` decorator, so without an
+    explicit emit here the most interesting line in the log — the agent
+    trying to delete a VLAN — would never be written at all.
+    """
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    await server.call_tool("delete_vlan", {"network_id": "net-1"})
+
+    events = _events(audit_log_path)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["tool"] == "delete_vlan"
+    assert ev["denied_by"] == DENIED_BY_READONLY
+    assert ev["success"] is False
+    assert ev["result"] is None
+    assert "read-only mode" in (ev["error"] or "")
+    assert ev["ts"].endswith("Z")
+    assert "client_id" in ev  # None on stdio, but the field must be present
+
+
+@pytest.mark.asyncio
+async def test_refusal_event_is_distinguishable_from_a_real_call(
+    stub_state: StubState, audit_log_path: Path
+) -> None:
+    """``denied_by`` is the one field an operator has to grep.
+
+    Both records carry ``success: false`` shapes in the wild (a tool that
+    raises records the same), so the answer to "what did my agent try to do
+    that it was not allowed to do" cannot be derived from ``success`` alone.
+    """
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    await server.call_tool("list_networks", {})
+    await server.call_tool("create_vlan", {"name": "X", "vlan_id": 9, "subnet": "10.0.9.0/24"})
+
+    events = _events(audit_log_path)
+    assert [e["tool"] for e in events] == ["list_networks", "create_vlan"]
+    assert events[0]["denied_by"] is None
+    assert events[0]["success"] is True
+    assert [e["tool"] for e in events if e["denied_by"]] == ["create_vlan"]
+
+
+@pytest.mark.asyncio
+async def test_permitted_read_in_readonly_mode_logs_no_refusal(
+    stub_state: StubState, audit_log_path: Path
+) -> None:
+    """Reads pass straight through; the gate must not annotate them."""
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    await server.call_tool("list_networks", {})
+    await server.call_tool("get_site_health", {})
+
+    events = _events(audit_log_path)
+    assert len(events) == 2
+    assert [e["denied_by"] for e in events] == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_refused_call_arguments_are_scrubbed(
+    stub_state: StubState, audit_log_path: Path
+) -> None:
+    """The refusal record is a persistent sink like any other audit line.
+
+    A refused ``create_wlan`` still carries whatever passphrase the caller
+    supplied. Writing it verbatim would reintroduce the exact leak the
+    redaction work closed, in the file operators are most likely to ship
+    off-box.
+    """
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    secret = "do-not-let-this-reach-the-audit-log"
+    await server.call_tool(
+        "create_wlan",
+        {"name": "WhisperNet", "passphrase": secret, "network_id": "net-1"},
+    )
+
+    raw = audit_log_path.read_text()
+    assert secret not in raw, "refused call leaked its passphrase into the audit log"
+    ev = _events(audit_log_path)[0]
+    assert ev["denied_by"] == DENIED_BY_READONLY
+    assert ev["args"]["passphrase"] == REDACTED
+    assert ev["args"]["name"] == "WhisperNet"
+
+
+@pytest.mark.asyncio
+async def test_refusal_record_survives_an_unresolvable_tool(audit_log_path: Path) -> None:
+    """The fail-closed branch must be audited too, not just the tagged one."""
+    from mcp_unifi.scoping import WriteGateMiddleware
+
+    class _Ctx:
+        def __init__(self) -> None:
+            self.message = type("M", (), {"name": "create_vlan", "arguments": {"a": 1}})()
+            self.fastmcp_context = None
+
+    async def call_next(_ctx: Any) -> Any:
+        pytest.fail("call_next must not run for a refused tool")
+
+    await WriteGateMiddleware(stub_mode=True).on_call_tool(_Ctx(), call_next)  # type: ignore[arg-type]
+    ev = _events(audit_log_path)[0]
+    assert ev["tool"] == "create_vlan"
+    assert ev["denied_by"] == DENIED_BY_READONLY
+    assert ev["args"] == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_audit_sink_failure_does_not_break_the_refusal(
+    stub_state: StubState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An audit outage must not turn a clean refusal into a transport error."""
+    from mcp_unifi import scoping
+
+    def _boom() -> Any:
+        raise RuntimeError("audit log is unavailable")
+
+    monkeypatch.setattr(scoping.audit, "get_audit_log", _boom)
+    server = build_server(_settings(readonly=True), stub=stub_state)
+    payload = _payload(await server.call_tool("delete_vlan", {"network_id": "net-1"}))
+    assert "read-only mode" in payload["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the follow-up flagged on #83: the read-only write gate refused calls and logged only a structured warning, so a denied mutation attempt left no trace in `audit.jsonl`. A security control that keeps no record of what it denied is only half a control, and the audit log is this repo's evidence surface.

## What changed

Both gate middlewares now write an audit event before turning the caller away, carrying a new `denied_by` field on `AuditEvent`:

| `denied_by` | Refused by |
|---|---|
| `"readonly"` | `WriteGateMiddleware` (`MCP_UNIFI_READONLY=true`) |
| `"scope"` | `ScopeMiddleware` (per-client module scoping) |
| `null` | Nothing — the call was dispatched |

```bash
jq -c 'select(.denied_by) | {ts, client_id, tool, denied_by}' audit.jsonl
```

## Why a separate field

`success: false` already means three different things in this log: the tool raised, the controller returned an error, or the call was never made. Only the third is a security event, and only a dedicated field distinguishes it without parsing prose. It also survives refusal-message rewording, and it separates the two controls — read-only is a property of the server ("turn the posture off"), scope is a property of the caller ("widen this client's token"), and an operator responds to them differently.

The record carries timestamp, tool, attempted args, and `client_id` where the transport has one (`null` on stdio).

## ScopeMiddleware is covered too

It is the sibling control with the same blind spot, and an operator asking "what was this client refused" wants one query, not two. Covering only the write gate would have left the other half of the same wall silent. The scope refusal keeps its deliberately vague *client-facing* message (a scoped client still cannot enumerate modules by reading denials) while the *audit* record names the control — the operator reading the log is entitled to detail the caller is not.

Scope sits outside the write gate in the chain, so a scoped client naming a mutating tool it cannot see produces exactly one event, attributed to scope.

## Redaction

Refusals go through `AuditLog.emit`, which means attempted arguments run through the same scrubber as a dispatched call. A refused `create_wlan` still arrives carrying the caller's passphrase, and the audit log is precisely the persistent sink the 0.20.0 redaction work was about — a test asserts the raw secret never reaches the file.

Emit failures are logged and swallowed. An audit outage must not convert a clean refusal envelope into a transport-level error, which would make the control look like it failed open.

## Replay

`mcp-unifi-replay` now skips events with `denied_by` set, reported like the existing off-target-controller skip. Without this, adding refusals to the log would have created a way to launder a denial: replaying a refused `delete_vlan` against a live controller performs the action the operator's own policy blocked. `parse_jsonl` treats a missing `denied_by` as `null`, so pre-0.21.0 logs replay unchanged.

## Tests

Verified red before the change (7 failures against the new source constants):

- `test_refused_call_writes_an_audit_event`
- `test_refusal_event_is_distinguishable_from_a_real_call`
- `test_refused_call_arguments_are_scrubbed`
- `test_refusal_record_survives_an_unresolvable_tool` (the fail-closed branch is audited too)
- `test_audit_sink_failure_does_not_break_the_refusal`
- `test_scope_denial_writes_an_audit_event`
- `test_scope_denial_scrubs_the_attempted_arguments`
- plus `test_replay_skips_refused_events` and `test_parse_jsonl_round_trips_denied_by`

`test_permitted_read_in_readonly_mode_logs_no_refusal` and `test_scope_permitted_call_writes_no_refusal_event` are negative controls and pass in both directions by design.

Full suite: 1078 passed, 89% coverage. `ruff check`, `ruff format --check`, `mypy src/mcp_unifi` all clean.

No version bump — Pete cuts the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
