### PR TITLE
release: 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.21.0] - 2026-08-12
 
 ### Added
 

--- a/charts/mcp-unifi/Chart.yaml
+++ b/charts/mcp-unifi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-unifi
 description: MCP server for self-hosted UniFi gateway management (Network + Protect + Access)
 type: application
-version: 0.2.4
-appVersion: "0.20.0"
+version: 0.2.5
+appVersion: "0.21.0"
 home: https://github.com/pete-builds/mcp-unifi
 sources:
   - https://github.com/pete-builds/mcp-unifi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   mcp-unifi:
-    image: ghcr.io/pete-builds/mcp-unifi:0.20.0
+    image: ghcr.io/pete-builds/mcp-unifi:0.21.0
     container_name: mcp-unifi
     restart: unless-stopped
     read_only: true

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "mcp-unifi",
   "display_name": "UniFi Gateway",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "MCP server for self-hosted UniFi gateway management.",
   "long_description": "Self-hosted UniFi gateway management: VLANs, WLANs, firewall, clients, DHCP, observability, UniFi Protect cameras, and UniFi Access doors / credentials / badge events. Multi-site, dry-run on destructive ops, replayable audit log. Stub mode lets you try the full tool surface with no hardware.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-unifi"
-version = "0.20.0"
+version = "0.21.0"
 description = "MCP server for self-hosted UniFi gateway management."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/pete-builds/mcp-unifi",
     "source": "github"
   },
-  "version": "0.20.0",
+  "version": "0.21.0",
   "websiteUrl": "https://pete-builds.github.io/mcp-unifi/",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.20.0",
+      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.21.0",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3714/mcp"

--- a/src/mcp_unifi/__init__.py
+++ b/src/mcp_unifi/__init__.py
@@ -19,4 +19,4 @@ a real UCG-Fiber, UDM Pro, or other UniFi OS gateway.
 
 from __future__ import annotations
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"


### PR DESCRIPTION
Cuts 0.21.0. Minor rather than patch: read-only mode is a new operating posture, not a fix.

## What's in it

**Read-only mode (`MCP_UNIFI_READONLY`)** — mutating tools are hidden from `tools/list` *and* refused on `tools/call`. Classification is declared per tool at registration via a required `mutates=` argument on the existing `@audited()` decorator, never inferred from tool names. Twelve mutating tools carry none of the obvious `create_`/`update_`/`delete_`/`set_` prefixes, `confirm_destructive_action` among them, so a name-based gate would have shipped a read-only mode that still let an agent commit a queued delete. Omitting the declaration is a `TypeError` at import, so a new tool cannot default into being callable. 134 tools: 62 mutating, 72 read.

**Refusals are now audited** — a new `denied_by` field (`"readonly"`, `"scope"`, or `null`) records what a control blocked and which control blocked it. A security control that leaves no record of its denials is half a control. Covers `ScopeMiddleware` as well as the write gate. `mcp-unifi-replay` skips these events: re-issuing a refused call would have turned the audit log into a way to launder a denial.

**`restore_config` warning correction** — 0.20.0 extended the stripped-secret force-disable to networks, but the warning still spoke only of WLAN passphrases, so the operator restoring a VPN tunnel was told nothing about what had just been turned off.

**Docs-site changelog** — was a stale mirror fifteen releases behind while reading as current, and was allowlisted out of the drift test that would otherwise have caught it. Now a pointer, and back under the drift test.

## Release surfaces

All seven the guard verifies, plus the chart's own `version` 0.2.4 → 0.2.5 so chart-releaser republishes under `CR_SKIP_EXISTING`. Guard and CHANGELOG notes extraction both run locally against this branch: seven surfaces ok, 85 lines of notes extracted.