### PR TITLE
ci: scan the image in the build job instead of shipping it as an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
           path: coverage.xml
           retention-days: 7
 
-  build-image:
-    name: Build Docker image
+  build-and-scan:
+    name: Build image + Trivy scan
     runs-on: ubuntu-latest
     needs: [lint-and-type, test]
     steps:
@@ -156,30 +156,6 @@ jobs:
           )
           print(f"image Python {sys.version.split()[0]} matches target {want[0]}.{want[1]}")
           '
-
-      - name: Save image for scan job
-        run: docker save mcp-unifi:ci -o /tmp/mcp-unifi.tar
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: docker-image
-          path: /tmp/mcp-unifi.tar
-          retention-days: 7
-
-  trivy-scan:
-    name: Trivy security scan
-    runs-on: ubuntu-latest
-    needs: build-image
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: docker-image
-          path: /tmp
-
-      - name: Load image
-        run: docker load -i /tmp/mcp-unifi.tar
 
       - name: Trivy fs scan (Dockerfile + lockfiles)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0


### PR DESCRIPTION
The `build-image` job saved the built image to a tar and uploaded it as a `docker-image` artifact purely so `trivy-scan` could download and `docker load` it. The handoff cost roughly two minutes per run, and the ~96MB tarball then sat in billed Actions storage for seven days on every push.

This repo alone was holding 2317MB of live `docker-image` artifacts against a 0.5GB monthly account allowance.

Merging the two jobs into `build-and-scan` keeps the image in the runner's local Docker daemon, so no artifact is produced at all.

Unchanged: both Trivy invocations, the pinned `aquasecurity/trivy-action@ed142fd` (v0.36.0) SHA, `severity: HIGH,CRITICAL`, `ignore-unfixed`, `exit-code: 1`, the `needs: [lint-and-type, test]` gate, and the `coverage-xml` upload.

No required status checks reference the old job names on this repo.