### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,10 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build (no push)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: false

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
 
       - name: Enable auto-merge (patch + minor only)
         if: steps.meta.outputs.update-type != 'version-update:semver-major'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build
         run: cd docs/site && npm run build
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/site/dist

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,12 +29,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
           charts_dir: charts
           mark_as_latest: "false"

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.ref_type == 'tag'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,13 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Extract version
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -122,7 +122,7 @@ jobs:
           push-to-registry: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with cosign (keyless OIDC)
         run: |
@@ -130,7 +130,7 @@ jobs:
             ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
 
       - name: Generate SBOM with Syft
-        uses: anchore/sbom-action@v0.24.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
           artifact-name: mcp-unifi-${{ github.ref_name }}-sbom.cyclonedx.json
@@ -179,7 +179,7 @@ jobs:
           echo "Extracted $(wc -l < /tmp/release-notes.md) lines of notes for ${VERSION}."
 
       - name: Attach release artifacts (SBOM + .dxt) and notes
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           body_path: /tmp/release-notes.md
           files: |


### PR DESCRIPTION
Pins third-party GitHub Actions to commit SHAs. A tag is mutable, so the upstream
owner can change what runs in CI at any time; a commit SHA cannot move.

The original tag is preserved as a trailing comment so the ref stays readable and
Dependabot can still see which version it is bumping from.

**`.github/workflows/ci.yml`**
- `docker/setup-buildx-action@v4` -> `bb05f3f5519d...`
- `docker/build-push-action@v7` -> `53b7df96c91f...`

**`.github/workflows/dependabot-auto-merge.yml`**
- `dependabot/fetch-metadata@v3` -> `25dd0e34f4fe...`

**`.github/workflows/docs.yml`**
- `peaceiris/actions-gh-pages@v4` -> `84c30a85c199...`

**`.github/workflows/helm-release.yml`**
- `azure/setup-helm@v5` -> `9bc31f4ebc9c...`
- `helm/chart-releaser-action@v1.7.0` -> `cae68fefc6b5...`

**`.github/workflows/publish-mcp.yml`**
- `docker/login-action@v4` -> `dbcb813823bd...`

**`.github/workflows/release.yml`**
- `docker/setup-qemu-action@v4` -> `96fe6ef7f335...`
- `docker/setup-buildx-action@v4` -> `bb05f3f5519d...`
- `docker/login-action@v4` -> `dbcb813823bd...`
- `docker/metadata-action@v6` -> `dc8028041006...`
- `docker/build-push-action@v7` -> `53b7df96c91f...`
- `sigstore/cosign-installer@v4.1.2` -> `6f9f17788090...`
- `anchore/sbom-action@v0.24.0` -> `e22c38990414...`
- `softprops/action-gh-release@v3` -> `3d0d9888cb7f...`

Opened as a draft by `scripts/pin-actions.py`. First-party `actions/*` refs are
deliberately left on tags.