### PR TITLE
ci: converge on full-recompile lockfile drift semantics

### DIFF
--- a/.github/workflows/lockfile-drift.yml
+++ b/.github/workflows/lockfile-drift.yml
@@ -1,0 +1,31 @@
+name: lockfile-drift
+
+# Full recompile + diff, the fleet's ONE meaning of "lockfile drift". The fleet used to
+# carry three: full recompile, pin-consistency-only, and no check at all. Pin consistency
+# lets TRANSITIVE dependencies drift arbitrarily far while staying green; measured on the
+# recompile loop's first run, pin-consistency repos had drifted 1 to 35 packages while
+# full-recompile repos sat at 0 to 2. This caller converges the repo on the strict
+# semantics.
+#
+# The implementation is the same one the lockfile-recompile loop uses (fleet-workflows,
+# pinned by SHA below), so the check and the fixer agree structurally about what
+# "current" means: same header-derived command, same fresh-temp-path compile, same
+# comments-stripped compare, same pinned uv.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Lockfile drift (full recompile)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pete-builds/fleet-workflows/lockfile-drift@47303e847995240aca7bd832c282cac38debf8b5 # v1.1.0
+        with:
+          uv-version: '0.12.5'   # must match the lockfile-recompile caller's pin


### PR DESCRIPTION
Adds the fleet's single lockfile-drift semantics, full recompile + diff, as a thin
caller of the SHA-pinned composite action in
[`pete-builds/fleet-workflows`](https://github.com/pete-builds/fleet-workflows).

**Why.** The fleet's "lockfile drift" checks were three different things: full recompile,
pin-consistency-only, and nothing. A pin-consistency check lets **transitive** dependencies
drift arbitrarily far while staying green; on the recompile loop's first run that predicted
the drift almost exactly (pin-consistency and no-check repos moved 1 to 35 packages,
full-recompile repos 0 to 2). This repo was in one of the weaker classes.

**What it checks.** On every PR and push to main: recompiles each tracked `*.lock` from the
command recorded in that lock's own header, to a fresh temp path, and fails if the committed
lock differs (comments stripped). It is the same implementation shape the
`lockfile-recompile` loop uses, so the detector and the fixer agree structurally about what
"current" means, including the pinned uv (`0.12.5`, matching the loop).

**When it goes red**, the fix is one dispatch: `gh workflow run lockfile-recompile.yml`
opens a PR that regenerates the lock. Detection and remediation are now the same shape.

**Credentials:** none. `contents: read` only.

**If this repo has an older, weaker lockfile check in ci.yml**, it is now strictly
redundant: the two can both be green or this one alone can be red, never the reverse.
Removing the old one is a small per-repo cleanup best done by hand, and this PR
deliberately does not attempt that surgery.

**Note on the first run.** If this check comes up red immediately, that is the point: the
lock has real transitive drift the old semantics could not see. Dispatch the recompile loop
and read the "What moved" line in its PR; a large bump count is a dependency upgrade, not a
lock sync, and deserves a real review.
