### PR TITLE
docs: six architecture decision records

### DIFF
--- a/docs/decisions/0001-explicit-write-classification.md
+++ b/docs/decisions/0001-explicit-write-classification.md
@@ -1,0 +1,100 @@
+# 0001. Classify tools as mutating by explicit declaration, not by name prefix
+
+**Status:** Accepted (v0.21.0)
+
+## Context
+
+`MCP_UNIFI_READONLY=true` is meant to make the server structurally unable to
+change anything: mutating tools are hidden from `tools/list` and refused on
+`tools/call`. That control needs to answer one question for every tool: does
+calling this change state outside this process?
+
+The server registers 134 tools across the `network`, `protect`, and `access`
+modules. 62 of them mutate. The question has to be answered for all 134, and it
+has to keep being answered correctly for every tool added later, by whoever adds
+it.
+
+The original scope proposed answering it from the tool name, gating anything
+starting with `create_`, `update_`, `delete_`, `set_`, `provision_`, `apply_`, or
+`reboot`.
+
+## Decision
+
+`mutates: bool` is a **required keyword-only argument** on the `@audited()`
+decorator that every tool already carries, declared at the registration site next
+to the tool body. Three layers enforce it:
+
+1. **Import time.** Omitting `mutates=` raises `TypeError` from Python itself.
+   There is no default, so a new tool cannot quietly inherit "read-only".
+2. **Registration time.** `register_modules()` in `src/mcp_unifi/dispatcher.py`
+   raises `UnclassifiedToolError` if a registered tool has no declaration, or if
+   the tool list cannot be enumerated at all (which would make tagging a silent
+   no-op). The server refuses to boot in either case.
+3. **CI.** `tests/test_write_gate.py::test_every_registered_tool_is_classified`
+   enumerates the live registration rather than any hand-maintained list, and
+   fails if anything is unclassified.
+
+A fourth guard, `ToolClassificationConflictError`, refuses registration when one
+tool name is declared with two different `mutates` values.
+
+## Alternatives considered
+
+**Name-prefix classification.** Rejected on measurement, not on taste. Enumerating
+the live registration shows **twelve mutating tools carry none of those prefixes**:
+`block_client`, `confirm_destructive_action`, `locate_device`, `quarantine_client`,
+`reconnect_client`, `rename_device`, `restart_device`, `restore_config`,
+`toggle_traffic_route`, `toggle_traffic_rule`, `trigger_speedtest`, and
+`unblock_client`.
+
+`confirm_destructive_action` is the one that kills the idea outright. It executes a
+delete that was queued by an earlier preview call. A prefix gate would have shipped
+a "read-only" mode that still commits previewed deletions, which is worse than no
+read-only mode at all because it reads as a guarantee. That specific case is pinned
+by its own test, `test_confirm_destructive_action_is_mutating`.
+
+The full pin list in the test carries thirteen names. The thirteenth,
+`backup_config`, is a pure read that a prefix gate would also have miscategorised,
+in the harmless direction. Both directions are asserted so the test stays honest
+about which is which.
+
+**An attribute on the wrapped function.** Rejected on mechanism: FastMCP re-wraps
+tool callables during registration, so an attribute set by the decorator is not
+guaranteed to survive onto `Tool.fn`. Classification is instead held in a
+process-level registry keyed by tool name, which is what the dispatcher reads when
+it tags tools and what the completeness test enumerates.
+
+**A separate allowlist or denylist file.** Rejected because it splits the
+classification from the code it describes. A reviewer would have to remember to
+open a second file, and nothing would fail if they did not.
+
+## Consequences and accepted costs
+
+- Every new tool costs one extra argument and one extra decision at write time.
+  That is the point, but it is still friction on every contribution.
+- Classification is a human judgement call, and the guards catch *missing*
+  declarations, not *wrong* ones. A tool declared `mutates=False` that actually
+  writes would pass all three layers. Nothing in the repo detects that today.
+- The registry is keyed by tool name and is process-global, so tool names must stay
+  globally unique across modules. `ToolClassificationConflictError` enforces this,
+  but it constrains module authors.
+- `_iter_registered_tools()` reads FastMCP's `_local_provider._components`, a
+  private attribute. A FastMCP upgrade that changes that shape degrades tagging to
+  a no-op, which is exactly why the empty-enumeration case raises rather than
+  returning quietly.
+
+## Reversal condition
+
+Revisit if **MCP or FastMCP grows a first-class read/write annotation on tool
+definitions** that clients and servers both understand. At that point the local
+registry becomes a private reimplementation of a protocol feature, and the
+declaration should move onto the standard annotation with the dispatcher reading
+that instead.
+
+A weaker trigger: if `_local_provider._components` breaks across a FastMCP major
+version and no supported enumeration API replaces it, layer 2 has to be rebuilt on
+whatever the SDK does expose, and this record should be rewritten rather than
+patched.
+
+Prefix classification does not come back under any condition. The twelve tools
+above are the proof, and they are pinned in CI so nobody rederives the shortcut and
+finds the tests still green.

--- a/docs/decisions/0002-shared-substrate-stays-off-pypi.md
+++ b/docs/decisions/0002-shared-substrate-stays-off-pypi.md
@@ -1,0 +1,89 @@
+# 0002. Keep the shared MCP substrate off PyPI
+
+**Status:** Accepted (fleet-level decision, 2026-08-12)
+
+## Context
+
+Several MCP servers in this fleet need the same plumbing: settings loading, a
+standard error envelope, structured logging with secret redaction, an audit sink.
+`pete-mcp-core` was extracted to hold that substrate.
+
+Three servers consume it: `mcp-searxng`, `mcp-spotify`, and `mcp-threatintel`. All
+three are the same author's, all three deploy as GHCR images pulled onto one host.
+Each declared `pete-mcp-core>=0.1.0` in its `pyproject.toml`, which meant install
+resolved against PyPI, where the package does not exist. Their CI was red for over
+a week for that reason alone.
+
+## Decision
+
+`pete-mcp-core` is **not published to PyPI**. Consumers depend on it through a PEP
+508 direct reference to an immutable commit tarball:
+
+```
+pete-mcp-core @ https://github.com/pete-builds/pete-mcp-core/archive/<sha>.tar.gz
+```
+
+Publishing to PyPI claims a permanent global name and immutable version filenames
+in a public registry, in order to buy version resolution that three private
+consumers on one host do not need.
+
+**This repository is not one of the three consumers.** `mcp-unifi` declares no
+dependency on `pete-mcp-core` and carries its own substrate: `config.py`,
+`audit.py`, `redaction.py`, `logging_setup.py`, `responses.py`. Whether that was a
+deliberate decision or simply the order things were built in is not recorded
+anywhere this record's author could verify. What is verifiable is the current
+state: no reference to `pete-mcp-core` exists anywhere in this repo. The record
+lives here because the same reasoning governs any future move of this repo's
+substrate into the shared package.
+
+## Alternatives considered
+
+**Publish to PyPI.** Rejected. The release workflow actually ran on 2026-08-09 and
+got as far as the publish job before failing with `invalid-publisher`: the trusted
+publisher had never been created, and creating one requires a pypi.org login. So
+the cost is not only the name claim, it is also a manual credential step outside
+CI. The benefit purchased is version-range resolution across three repos with one
+owner, which is not a problem those repos have.
+
+**`git+https://` dependency URLs.** Rejected on packaging mechanics rather than
+policy. pip installs a plain tarball with no `git` binary present, but a
+`git+https` reference needs one. Using tarballs kept the `python:3.13-slim` runtime
+images unchanged. This mattered most in `mcp-spotify`, whose Dockerfile is single
+stage, where `git` would have shipped in the runtime layer.
+
+**A private package index.** Rejected as more infrastructure to run, monitor, and
+secure than the dependency it would serve.
+
+**Vendoring the substrate into each consumer.** This is effectively what
+`mcp-unifi` does today. It removes the dependency question entirely and costs
+divergence: a fix to redaction has to be made in each copy, and the copies drift.
+Acceptable for one repo, not as a fleet strategy.
+
+## Consequences and accepted costs
+
+- **Dependabot cannot see through a SHA pin.** A direct reference to a commit
+  tarball is opaque to it. When `pete-mcp-core` changes, the SHA has to be bumped
+  by hand in all three dependent repos. Nothing will open a PR to remind anyone.
+  This is the accepted cost and it is the whole cost.
+- Consumers need `[tool.hatch.metadata] allow-direct-references = true`, because
+  hatchling rejects direct references otherwise. That line has to be explained to
+  anyone reading those `pyproject.toml` files.
+- A `v0.1.0` tag exists on `pete-mcp-core`, points at a commit behind `main`, and
+  is inert. Nothing was ever published under it. Re-pushing it re-fires the release
+  workflow into the same red run.
+- Anyone outside this fleet who wants the substrate has to install from a GitHub
+  URL rather than `pip install pete-mcp-core`.
+
+## Reversal condition
+
+Publish to PyPI when **a consumer exists that is not the author's own**, or when
+the servers stop being deployed as pinned GHCR images and start being installed as
+libraries by someone who needs version ranges. Either one turns "versioning nobody
+needs" into versioning someone needs.
+
+A second, weaker trigger: if manual SHA bumps across three repos are ever missed
+long enough that a security fix in the substrate sits undeployed, the Dependabot
+blindness has become the more expensive side of the trade and the decision should
+be re-costed.
+
+Until then this is the standing answer, not a stopgap.

--- a/docs/decisions/0003-verify-ssl-defaults-off.md
+++ b/docs/decisions/0003-verify-ssl-defaults-off.md
@@ -1,0 +1,78 @@
+# 0003. `verify_ssl` defaults to `false`
+
+**Status:** Accepted
+
+## Context
+
+Every HTTP client in this server takes a `verify_ssl` flag: `clients/unifi.py`,
+`clients/unifi_os.py`, `clients/protect.py`, and `clients/access.py`. It flows from
+`Settings` (`unifi_verify_ssl`) or from a per-controller entry in the controllers
+YAML (`ControllerConfig.verify_ssl`).
+
+The primary deployment target is a self-hosted UniFi gateway on a home LAN,
+reached at `https://<lan-ip>:443/proxy/network`. Those consoles ship a self-signed
+certificate for an IP address. There is no hostname to match and no chain to walk.
+
+An external fork, `adibirzu/mcp-unifi`, flipped the default to `true`.
+
+## Decision
+
+`verify_ssl` defaults to `false` in both `ControllerConfig` and the legacy
+single-controller `Settings` fields, at `src/mcp_unifi/config.py:60` and
+`src/mcp_unifi/config.py:168`. Operators who terminate TLS with a real certificate
+set it to `true` per controller.
+
+## Alternatives considered
+
+**Default to `true`, as the fork did.** Rejected on out-of-box behaviour. Against
+the primary target, a `true` default turns the first tool call into a TLS
+verification error. The failure surfaces to the user as a broken MCP server, and
+the fix is a config flag they have not read about yet. The decision trades a
+strictly better default *for a deployment shape this server is not primarily aimed
+at* against a working first run for the shape it is.
+
+This was a real trade-off against a real contributor, not a dismissal. **Two of
+that fork's three findings were accepted** and became the v0.20.0 secret-redaction
+work: the substring pattern gap where `psk` matched `wpa_psk` but nothing in
+`x_ipsec_pre_shared_key` or `x_preshared_key`, and the wiring gap where `redact()`
+only ran where a module happened to call it. Adrian Birzu (`@adibirzu`) is credited
+by name in the CHANGELOG for both. Only the TLS default was declined.
+
+**Default to `true` with an automatic fallback to `false` on a verification
+failure.** Rejected outright. A client that silently downgrades on TLS failure has
+the security posture of `false` while presenting the posture of `true`, which is
+worse than either. If verification is on it has to fail closed.
+
+**Pin the console's self-signed certificate.** A real option and strictly better
+than either default: verification against a pinned cert, no CA needed. Not built,
+because it needs a fetch-and-trust bootstrap step, per-controller cert storage, and
+a rotation story. Recorded here as the alternative most likely to make this
+decision obsolete.
+
+## Consequences and accepted costs
+
+- **The default configuration does not authenticate the controller.** On a LAN
+  segment an attacker able to intercept traffic to the gateway IP could
+  man-in-the-middle the API key and every configuration read and write. This is the
+  accepted cost and it should not be softened. The mitigating context is that the
+  threat model is a home LAN, the controller is on the same broadcast domain as the
+  server, and an attacker with that position already has other paths. That is
+  context, not a reason the risk is absent.
+- Anyone who deploys this against a controller reachable over an untrusted network
+  and does not read the flag inherits that exposure by default.
+- The default diverges from the `adibirzu` fork, so configuration written against
+  one is not portable to the other without checking this flag.
+
+## Reversal condition
+
+Flip the default to `true` when **UniFi ships consoles with a verifiable
+certificate out of the box**, or when the primary deployment target stops being a
+self-signed LAN gateway.
+
+Implement certificate pinning, and make it the default, if the server ever gains a
+first-run bootstrap step where fetching and trusting the console's certificate can
+happen without the user writing config by hand. That would remove the trade-off
+rather than resolving it in either direction.
+
+An interim step that needs no decision reversal: emitting a one-time startup
+warning naming each controller running unverified. That is not implemented today.

--- a/docs/decisions/0004-confirm-token-is-ceremony-not-consent.md
+++ b/docs/decisions/0004-confirm-token-is-ceremony-not-consent.md
@@ -1,0 +1,95 @@
+# 0004. The confirm-token handshake is ceremony, not consent
+
+**Status:** Accepted as an interim control, with a known and stated inadequacy.
+Not equivalent to the "Accepted" in the other records here.
+
+## Context
+
+Twelve tools use a preview-then-confirm handshake: `delete_content_filter`,
+`delete_dynamic_dns`, `delete_firewall_group`, `delete_firewall_rule`,
+`delete_honeypot`, `delete_port_forward`, `delete_port_profile`, `delete_route`,
+`delete_static_dhcp_lease`, `delete_vlan`, `delete_wlan`, and `set_guest_portal`.
+
+Calling one of them does not mutate the controller. It resolves the target, mints a
+UUID4 token into an in-process registry with a 300 second TTL, and returns a
+preview envelope naming the resource and the token. The change commits only when
+`confirm_destructive_action(token)` runs. Implementation is in
+`src/mcp_unifi/modules/network/_pending.py`.
+
+The pattern reads like a confirmation prompt. It is not one.
+
+## Decision
+
+Keep the handshake, and state plainly what it does and does not provide.
+
+**What it provides:** a preview of the exact resource that will be destroyed before
+anything is destroyed, a bounded window in which nothing has happened yet, an
+`_id`-resolved target so a wrong-object mistake is visible in the preview, and two
+distinct audit records for one destructive action.
+
+**What it does not provide: consent.** Both calls are made by the same caller. When
+that caller is an autonomous agent, the agent previews, reads its own preview, and
+confirms, all inside one turn, with no human between the two calls. Against that
+threat model the handshake is ceremony. It proves nothing about human intent, and
+it must not be described as a safety control that requires approval.
+
+## Alternatives considered
+
+**A bespoke out-of-band approval channel**, for example posting the preview to
+Discord and waiting for a reaction before the token becomes usable. Rejected. It
+would be real consent, and it would also mean this MCP server owns a chat
+integration, a webhook listener, a secret for it, a timeout policy, and an
+availability dependency where a destructive operation blocks on a third-party
+service being reachable. That is a large, permanently-owned surface bolted onto a
+server whose job is to talk to a network controller. It also only works for one
+operator on one platform.
+
+**MCP elicitation routed through the harness.** This is the right shape. The
+protocol has a flow for a server to ask the client to put a question to the human,
+and the client is where a human already is. The server would ask, the harness would
+prompt, and the answer would carry actual human intent rather than an agent's echo
+of its own request.
+
+Not implemented. Two things would need checking first, and neither has been
+verified for this record: whether the pinned `fastmcp==3.4.6` and `mcp==1.29.0`
+expose the flow usably from a tool body, and whether the clients this server is
+actually used from implement the client half. An elicitation call that the client
+silently declines would be a third form of ceremony, so this needs proving before
+it ships, not assuming.
+
+**Requiring a human-supplied confirmation phrase as a tool argument.** Rejected: an
+agent can supply any string a docstring tells it to supply. It moves the ceremony,
+it does not remove it.
+
+**Removing the handshake entirely and relying on read-only mode (ADR 0001).**
+Rejected because the preview has value independent of consent. Seeing the resolved
+resource before deleting it catches wrong-target errors, which are the common
+failure, whereas consent addresses the rare one.
+
+## Consequences and accepted costs
+
+- **A control that looks stronger than it is, which is the specific risk of
+  documenting it badly.** Anyone who reads "preview then confirm" and infers human
+  approval has been misled. This record exists mainly to prevent that reading.
+- Tokens live in a process-global registry with no persistence. A restart drops
+  every pending action, and the preview has to be re-run. That is the correct
+  failure direction and it is still a rough edge.
+- Every destructive operation costs two round trips.
+- `confirm_destructive_action` is itself classified `mutates=True` (ADR 0001), so
+  read-only mode blocks the commit half. Read-only mode, not this handshake, is the
+  control that actually stops an autonomous agent from completing a delete.
+
+## Reversal condition
+
+Replace the handshake with **MCP elicitation through the harness** as soon as both
+halves are confirmed present: the pinned SDK exposes the flow from a tool body, and
+the clients in use implement it. At that point the preview stays, the local token
+registry goes, and this record is superseded rather than amended.
+
+Reverse in the other direction, removing the handshake, if elicitation lands and a
+preview turns out to be redundant with what the elicitation prompt already shows
+the human. Carrying both would be two confirmations for one action.
+
+Do not build the out-of-band channel. If someone proposes it again, the reason it
+was rejected is ownership cost and availability coupling, and neither of those
+changes because the idea is raised a second time.

--- a/docs/decisions/0005-writes-stay-on-the-private-network-api.md
+++ b/docs/decisions/0005-writes-stay-on-the-private-network-api.md
@@ -14,10 +14,12 @@ UniFi exposes two API surfaces on a self-hosted console:
 
 This server runs entirely on the first one. `src/mcp_unifi/clients/unifi.py` builds
 its base as `https://{host}:{port}/proxy/network` with a site path of
-`/api/s/{site}`, and every write goes through it: 28 calls under `/rest/*`, four
-under `/cmd/*`, one under `/set/*`. The v2 tree is referenced in 27 places for the
-reads that only exist there. **There is not a single call to `/integration/v1` in
-the codebase.**
+`/api/s/{site}`, and every configuration write goes through it. Counting the
+mutating HTTP calls in that one file: 28 under `/rest/*`, four under `/cmd/*`, one
+under `/set/*`. The v2 tree is referenced in 27 places for the reads that only
+exist there. The other clients (`unifi_os.py`, `protect.py`, `access.py`) issue no
+configuration writes at all; the single POST among them is a console login.
+**There is not one call to `/integration/v1` anywhere in the codebase.**
 
 The fragility is not hypothetical. Live probes against a UCG-Fiber recorded in
 `clients/unifi.py` and `SESSION-RESUME.md` found `GET` and `POST /stat/event`

--- a/docs/decisions/0005-writes-stay-on-the-private-network-api.md
+++ b/docs/decisions/0005-writes-stay-on-the-private-network-api.md
@@ -1,0 +1,98 @@
+# 0005. Writes stay on the private UniFi Network API
+
+**Status:** Accepted, with an outstanding documentation task
+
+## Context
+
+UniFi exposes two API surfaces on a self-hosted console:
+
+- The **private Network API** behind `/proxy/network/api/s/<site>/...`, plus a
+  newer `/proxy/network/v2/api/site/<site>/...` tree. Undocumented, unversioned,
+  and free to change between firmware releases.
+- The **official Integration API** at `/proxy/network/integration/v1/...`.
+  Documented and versioned.
+
+This server runs entirely on the first one. `src/mcp_unifi/clients/unifi.py` builds
+its base as `https://{host}:{port}/proxy/network` with a site path of
+`/api/s/{site}`, and every write goes through it: 28 calls under `/rest/*`, four
+under `/cmd/*`, one under `/set/*`. The v2 tree is referenced in 27 places for the
+reads that only exist there. **There is not a single call to `/integration/v1` in
+the codebase.**
+
+The fragility is not hypothetical. Live probes against a UCG-Fiber recorded in
+`clients/unifi.py` and `SESSION-RESUME.md` found `GET` and `POST /stat/event`
+returning 404 `api.err.NotFound` on Network 10.4.57, still 404 on 10.5.67, with
+sibling `stat/*` routes answering 200 on the same key. A route this server depends
+on simply was not there.
+
+## Decision
+
+Keep writes on the private API. Do not migrate.
+
+The reason is capability, not effort. The same probe that found the missing event
+route also checked the official surface: **Integration v1 on that firmware exposes
+only `devices` and `clients`.** It has no firewall rules, no VLANs, no WLANs, no
+port forwards, no routes, no DHCP reservations, no port profiles. Migrating would
+not be a like-for-like port. It would delete most of the tool surface.
+
+## Alternatives considered
+
+**Migrate everything to the Integration API.** Rejected. It cannot express the
+operations this server exists to perform. A stable API for a capability set that
+excludes the capability is not a substitute.
+
+**Hybrid: use the Integration API where it covers the operation, private endpoints
+elsewhere.** Rejected for now, and this is the closest call in this record. The
+benefit is narrow, because the covered surface is `devices` and `clients`, which is
+a small slice of a 134-tool server. The cost is two client code paths, two auth
+shapes to keep working, two error-envelope translations, and a rule about which
+surface a given tool uses that every future contributor has to learn. That is a
+permanent structural tax for stability on a minority of calls.
+
+**Pin a supported firmware range and refuse to run outside it.** Rejected as
+hostile to users, who do not control when a UniFi console updates itself.
+
+**Defensive degradation, which is what is actually built.** Where a private route
+is known to be absent on current firmware, the client tolerates it rather than
+raising. `list_events` GETs `/stat/event` and returns an empty list on the expected
+404 or 400, logged at INFO, forward-compatible with a firmware that restores the
+route. This does not remove the fragility, it contains one known instance of it.
+
+## Consequences and accepted costs
+
+- **A firmware update can break writes with no warning and no deprecation notice.**
+  There is no contract to appeal to. This is the accepted cost and it is the real
+  one.
+- Breakage is discovered in production, by a user, at the moment they try to change
+  something.
+- Endpoint behaviour recorded here was probed against specific firmware versions on
+  one hardware model. Nothing guarantees another console behaves the same way.
+- The codebase carries thirteen separate places in `clients/unifi.py` alone where a
+  firmware quirk or a probe result had to be written down in a docstring, because
+  no vendor documentation records it.
+
+**Outstanding task, stated rather than implied:** the honest interim is a
+documentation pass marking, per write tool, which endpoint it rides and what is
+known about that endpoint's stability. **That pass has not been done.** What can be
+stated cheaply and accurately today is the coarse version: *every* write in this
+server rides the private surface, so no write carries a stability guarantee. The
+per-endpoint detail, which routes have been probed live against which firmware and
+which have only ever been exercised in stub mode, is not currently collected
+anywhere a user can read it.
+
+## Reversal condition
+
+Migrate a capability to the Integration API the first release in which **that
+capability appears there**, checked against a live probe rather than release notes.
+The trigger is per-capability, not all-or-nothing, and it reverses the hybrid
+rejection above: once the covered surface is large enough that the two-code-path
+tax buys stability for most calls rather than a minority, the hybrid becomes
+correct.
+
+The concrete check: re-probe `/proxy/network/integration/v1/` on current firmware
+and see whether firewall, network, and WLAN resources exist. If they do, this
+record is superseded.
+
+Reverse sooner, and accept the hybrid tax immediately, if a firmware update breaks
+a private write endpoint that the Integration API already covers. One real outage
+in that shape settles the cost argument.

--- a/docs/decisions/0006-denied-by-is-a-separate-audit-field.md
+++ b/docs/decisions/0006-denied-by-is-a-separate-audit-field.md
@@ -1,0 +1,115 @@
+# 0006. `denied_by` is a separate audit field, not a convention on `error`
+
+**Status:** Accepted (v0.21.0)
+
+## Context
+
+Every tool call emits one `AuditEvent` as a JSON line
+(`src/mcp_unifi/audit.py`). The envelope carries `success: bool` and
+`error: str | None`.
+
+Two controls can refuse a call before the tool body runs: the read-only write gate
+(ADR 0001) and per-client module scoping. Both need to appear in the audit log,
+because a control that keeps no record of what it denied is only half a control.
+
+The problem is that `success: false` already means three different things in this
+log:
+
+1. The tool body raised.
+2. The controller returned an error.
+3. The call was never made, because a control refused it.
+
+Only the third is a security event. Nothing in `success` or `error` distinguishes
+it.
+
+## Decision
+
+Add `denied_by: str | None` to the audit envelope. It carries `"readonly"` for the
+write gate and `"scope"` for per-client module scoping (`DENIED_BY_READONLY` and
+`DENIED_BY_SCOPE` in `src/mcp_unifi/scoping.py`), and is `None` on every call that
+was actually dispatched.
+
+The security query becomes `jq 'select(.denied_by)'`.
+
+The two values are kept distinct rather than collapsed to a boolean because the
+operator's response to each differs: read-only is a property of the server, so the
+fix is "turn the posture off", while scope is a property of the caller, so the fix
+is "widen this client's token".
+
+## Alternatives considered
+
+**A prefix or marker convention on `error`,** for example `"REFUSED: ..."`.
+Rejected. It makes the security query a regex over prose. Prose gets reworded, gets
+translated, gets a variable interpolated into the middle of it, and the regex
+quietly stops matching with nothing failing. A structured field either exists or
+does not.
+
+**Deriving refusals from `success: false` plus an absent `result`.** Rejected: it
+is inference over an envelope that was never designed to carry that distinction,
+and it would also catch tools that raised before producing a result.
+
+**A separate refusal log file.** Rejected. Refusals and dispatched calls belong in
+one ordered stream, because the interesting question is usually what a caller did
+immediately before or after being refused.
+
+## The deliberate asymmetry, and why it is not an oversight
+
+The message the client sees and the record the operator sees are intentionally
+different.
+
+On a scope refusal the client gets: `Tool 'x' is not available to this client.`
+That is all. It does not say which module the tool belongs to, that modules exist,
+or which ones this client can reach. A scoped client that could read a specific
+denial message could enumerate the whole tool surface by brute-forcing names and
+diffing the responses. Vagueness is the control.
+
+The audit record for the same refusal is the opposite side of that wall. It names
+the control (`denied_by: "scope"`), names the mechanism in `error`
+(`Refused by per-client module scoping (MCP_UNIFI_AUTH_TOKENS)`), states that no
+call reached the controller, and records the tool name and the arguments, scrubbed
+of secrets. The operator reading the log is entitled to detail the caller is not.
+
+Anyone tempted to "fix" the unhelpful client message by making it specific would be
+removing a control, not improving an error string.
+
+## Replay reads this field, and that is a safety property
+
+`mcp-unifi-replay` (`src/mcp_unifi/cli/replay.py`) skips any event with
+`denied_by` set, recording it as skipped with the reason
+`refused at capture time by <control>; never dispatched`.
+
+This does not belong in a section of its own, because it is not a separate
+decision. It is the reason the field has to be structured. Replaying a refused
+delete would perform the exact action the operator's own policy blocked, which
+would turn the audit log into a way to launder a denial. A replay tool that had to
+decide by matching a substring in `error` would do that the first time the message
+was reworded.
+
+## Consequences and accepted costs
+
+- One more field on every audit line, `null` on the overwhelming majority of them.
+- The envelope's `schema` version stays at `"1"`. Older logs missing the field
+  parse via the dataclass default, so `denied_by` reads as `None` for them.
+  **A log written before v0.21.0 is indistinguishable from one where nothing was
+  ever refused.** Anyone reasoning about historical refusal rates has to check the
+  server version that produced the log.
+- Every future control that can refuse a call has to remember to set this field, or
+  its refusals become invisible to the standard query. Nothing enforces that today.
+  The `DENIED_BY_*` constants live next to each other in `scoping.py` partly to
+  make the omission visible on review.
+- The vague client-facing message costs debuggability. An operator debugging a
+  legitimately-scoped client sees an unhelpful error and has to go to the audit log
+  to learn why.
+
+## Reversal condition
+
+Split `denied_by` into a richer structure, for example `{control, policy_id,
+subject}`, when **a third refusing control lands** and the flat string stops
+carrying enough to answer "why". Two values fit in a string. Five, with per-policy
+identifiers, do not.
+
+Bump the `schema` version at the same time, which is the change that would let a
+consumer tell "no refusals" apart from "a server too old to record them".
+
+Fold it back into `error` under no condition. The regex-over-prose failure mode is
+the reason the field exists, and the replay skip depends on it being structured.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,57 @@
+# Architecture Decision Records
+
+Records of decisions already made in this codebase, written so a reader can see
+the alternatives that were considered, why the losers lost, and what would change
+the answer.
+
+Every record carries a **reversal condition**: the concrete, checkable thing that
+would make this decision wrong. A record without one is a rationalisation, so if a
+future ADR here lacks one, it is not finished.
+
+Where a decision has a real downside, the record names it under **Consequences and
+accepted costs**. A decision with no downside listed has not been examined.
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-explicit-write-classification.md) | Classify tools as mutating by explicit declaration, not by name prefix | Accepted |
+| [0002](0002-shared-substrate-stays-off-pypi.md) | Keep the shared MCP substrate off PyPI | Accepted (fleet-level; this repo is not a consumer) |
+| [0003](0003-verify-ssl-defaults-off.md) | `verify_ssl` defaults to `false` | Accepted |
+| [0004](0004-confirm-token-is-ceremony-not-consent.md) | The confirm-token handshake is ceremony, not consent | Interim control, known inadequate |
+| [0005](0005-writes-stay-on-the-private-network-api.md) | Writes stay on the private UniFi Network API | Accepted, with an outstanding documentation task |
+| [0006](0006-denied-by-is-a-separate-audit-field.md) | `denied_by` is a separate audit field, not a convention on `error` | Accepted |
+
+## Template
+
+New records use the same six sections:
+
+```markdown
+# NNNN. Title in the imperative or as a statement of the decision
+
+**Status:** Proposed | Accepted | Superseded by NNNN | Interim, with a stated inadequacy
+
+## Context
+What forced a decision. Facts, measurements, constraints.
+
+## Decision
+What was chosen, and where it lives in the code.
+
+## Alternatives considered
+Each one that was genuinely on the table, and the specific reason it lost.
+"It was worse" is not a reason.
+
+## Consequences and accepted costs
+What this decision costs. Name the downside plainly.
+
+## Reversal condition
+The concrete thing that would make this decision wrong, stated so someone could
+check it later without asking the author.
+```
+
+## Conventions
+
+- Numbers are sequential and never reused. A superseded record stays in place with
+  its status updated, pointing at the record that replaced it.
+- Records describe decisions **already made in the code**. They are not proposals.
+- Claims are verified against the code at the time of writing. Where something
+  could not be verified, the record says so rather than implying a verification
+  that did not happen.


### PR DESCRIPTION
## What this is

Six written records of decisions that were already made in this server's code, plus an index page. Nothing in `src/` changed. This is documentation only.

An external reviewer read the public repos and said they show the chosen solution well but never show the alternatives. His words: "Here were three viable architectures, here's why I rejected two, and here's what would make me change the decision." These records answer that.

## What each record has to carry

Every one of the six states the decision, the alternatives genuinely on the table, the specific reason each rejected option lost, the accepted cost of the choice, and a **reversal condition**: the concrete, checkable thing that would make the decision wrong later. The index page says plainly that a record without a reversal condition is a rationalisation, so the bar holds for anything added later.

## The six

1. **Tools declare whether they mutate; the write gate never guesses from the name.** The rejected design gated on name prefixes like `create_` and `delete_`. Enumerating the live registration shows twelve mutating tools carry none of those prefixes, including the one that executes a queued delete. That shortcut would have shipped a "read-only" mode that still commits previewed deletions.
2. **The shared substrate package stays off PyPI.** Three consumers, all yours, all deployed as pinned images, so publishing would claim a permanent global name to buy versioning nobody needs. The record names the cost: Dependabot cannot see through a commit pin, so substrate changes are a manual bump in three repos.
3. **TLS verification is off by default.** The primary target is a self-signed home gateway, so verifying by default makes the first tool call a TLS error. The record is honest that this was declined against a real outside contributor whose other two findings were accepted, and it states the actual security cost rather than softening it.
4. **The preview-then-confirm handshake is ceremony, not consent.** Both calls come from the same agent, so it proves nothing about human intent. Its status is deliberately not "Accepted" in the same sense as the others: it is an interim control with a stated inadequacy, and the record says what should replace it.
5. **Writes stay on the undocumented UniFi endpoints.** Not from laziness: the official API on this firmware covers only devices and clients, so migrating would delete most of the tool surface. The record states plainly that the per-endpoint fragility markup has not been done, rather than implying it has.
6. **Refused calls get their own audit field.** `success: false` already meant three different things and only one of them is a security event. The record also documents why the message a client sees is deliberately vaguer than the audit record, and why the replay tool must skip refused events.

## Verification

Every factual claim was checked against the current code rather than taken from notes. Two places where the check changed what got written are called out in the records themselves. Where something could not be verified, the record says so instead of implying otherwise.

## CI

`docs/decisions/` sits outside the file patterns the docs-drift test scans and outside the docs-site workflow's path filter, so nothing new is gated on it. The drift test and the write-gate test suite were both run locally and pass.