### PR TITLE
ci: a coverage-upload failure can no longer skip the Trivy scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,14 @@ jobs:
       - name: Run pytest
         run: pytest --cov-report=term --cov-report=xml --cov-fail-under=80
 
+      # coverage.xml is a convenience artifact, not a gate. When the account's
+      # artifact storage quota is full this step fails, which fails the whole
+      # test job, which skips the downstream Trivy scan that depends on it. A
+      # storage problem must not be able to switch the security gate off, so
+      # this step is allowed to fail on its own. Seen live in phish-vault.
       - name: Upload coverage
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: coverage-xml
           path: coverage.xml


### PR DESCRIPTION
Preventive: this is the defect that has had **phish-vault** red since yesterday, and this repo has the identical shape.

There, the tests passed the whole time (117 passed, 86% coverage). The step *after* them failed:

```
##[error]Failed to CreateArtifact: Artifact storage quota has been hit.
```

That failed the `test` job, and `build-and-scan` has `needs: [..., test]`, so **the job running Trivy was skipped on every run**. The artifact storage quota is account-wide, so this repo is exposed to the same failure and has the same blocking `upload-artifact` gating the same scan job.

The bad part is the direction of the failure: a full artifact store silently switches the security gate off, while the red X points at coverage.

`coverage.xml` is a convenience artifact, not a gate, so it is now allowed to fail on its own. Tests and the coverage floor still gate normally, since `pytest --cov-fail-under=80` runs before this step, and `build-and-scan` keeps its `needs` on `test`, so a genuine test failure still blocks the scan.

Companion PRs: phish-vault #62 (where it is live), mcp-unifi, open-setlist-stash.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>