### PR TITLE
security: anchor the id allowlist at end-of-string, and make the snapshot traversal test able to fail

### DIFF
--- a/src/mcp_unifi/clients/ids.py
+++ b/src/mcp_unifi/clients/ids.py
@@ -27,11 +27,14 @@ import re
 
 from mcp_unifi.clients.errors import UniFiError
 
-#: Characters a single path segment may contain. Colon is included for MAC
+#: Characters a single path segment may contain. Anchored with ``\A``/``\Z``
+#: rather than ``^``/``$``: Python's ``$`` also matches just before a trailing
+#: newline, so ``"abc\n"`` would satisfy an allowlist documented as strict.
+#: Colon is included for MAC
 #: addresses (``AA:BB:CC:DD:EE:FF``), which some device routes take in place of
 #: an ``_id``. Dot is included because a few controller keys contain one, and
 #: the bare ``.`` / ``..`` segments are refused separately below.
-_SEGMENT = re.compile(r"^[A-Za-z0-9_.:-]+$")
+_SEGMENT = re.compile(r"\A[A-Za-z0-9_.:-]+\Z")
 
 #: Longest id the gateway is known to issue is 24 characters; MACs are 17.
 #: A generous ceiling still stops a pathological argument from becoming a

--- a/tests/protect/test_real_mode.py
+++ b/tests/protect/test_real_mode.py
@@ -537,12 +537,19 @@ async def test_real_get_camera_rejects_path_traversal(real_protect_server: FastM
 
 @respx.mock
 async def test_real_get_snapshot_rejects_path_traversal(real_protect_server: FastMCP) -> None:
-    """The binary path has the same shape and must fail the same way."""
+    """The binary path has the same shape and must fail the same way.
+
+    Three ``../`` segments, not two: the client base is
+    ``/proxy/protect/api`` and the route adds ``/cameras/<id>/snapshot``, so
+    two levels only reach ``/proxy/protect/network/...`` and never leave the
+    Protect app. With two, the mocked Network route below can never be hit
+    and ``escaped.called`` proves nothing.
+    """
     escaped = respx.get(url__regex=r".*/proxy/network/.*").mock(
         return_value=httpx.Response(200, content=b"\xff\xd8secret")
     )
     result = await _call(
-        real_protect_server, "get_snapshot", {"camera_id": "../../network/api/s/default/self"}
+        real_protect_server, "get_snapshot", {"camera_id": "../../../network/api/s/default/self"}
     )
     assert "error" in result
     assert not escaped.called

--- a/tests/test_path_segment.py
+++ b/tests/test_path_segment.py
@@ -47,6 +47,8 @@ def test_path_segment_accepts_plain_identifiers(value: str) -> None:
         "a b",
         "a%2e%2e",
         "a\nb",
+        "a\n",
+        "a\r\n",
         "a;b",
         "a\\b",
         "a" * 129,


### PR DESCRIPTION
Follow-up to #125. Both fixes were reviewed and approved against that PR and pushed to its branch, but #125 was squash-merged at `6ee936b` a few minutes before, so neither reached `main`. This carries the same commit on top of the merged result.

## Two controls that looked present and did less than they claimed

**1. The allowlist accepted a trailing newline.** `ids.py` anchored with `^...$`, and Python's `$` also matches just before a trailing newline, so `"abc\n"` satisfied a pattern whose docstring promises to refuse any character outside `[A-Za-z0-9_.:-]`.

Not reachable today: httpx raises `InvalidURL` on a newline in a path, which is why nothing caught it. But the validator was leaning on a dependency for a guarantee it makes itself. Now anchored `\A...\Z`. The reject table gains `"a\n"` and `"a\r\n"`.

**2. The `get_snapshot` traversal test could not fail.** It used two `../`. The Protect client base is `/proxy/protect/api` and the route adds `/cameras/<id>/snapshot`, so two levels only reach `/proxy/protect/network/...` and never leave the Protect app. The mocked Network route it asserts against could therefore never be hit, and `assert not escaped.called` was dead weight. Three levels reach `/proxy/network/` and the mock does fire.

## Verified by making each control fail on purpose

- `"a\n"` **fails** against the old `$` anchor and **passes** with `\A`/`\Z`, so the new case detects the bug rather than trusting it.
- With `path_segment` neutered, both traversal tests now fail on `assert "error" in result` with the escaped response body visible in the assertion. With the two-level payload the snapshot test instead failed with respx `AllMockedAssertionError` — the confusing failure its sibling's docstring explicitly says to avoid.
- The camera traversal test was already correct and is unchanged. Its control run also confirms #125's second layer works: with validation disabled the Network record came back with the passphrase already `[REDACTED]`.

## Gate

`pytest` 1153 passed, coverage 89.06% (gate 80%). `mypy --strict` clean. `ruff format --check` clean. `ruff check` clean on these three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uuux6s8EY5vTxPMRXSMTs