### PR TITLE
security: redact update_vlan, attribute confirms to their controller, stop replaying writes, merge port overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`update_vlan` redacts the record it returns and the patch it previews.**
+  Network records carry VPN key material (`x_ipsec_pre_shared_key`, WireGuard
+  `x_private_key`, RADIUS `x_secret`), and the read tools redacted it while
+  `update_vlan` returned the re-read record raw and echoed the caller's patch
+  raw in `dry_run`. Toggling `enabled` on a site-to-site VPN network put the
+  pre-shared key in the transcript. Both paths now go through `redact`, as
+  `update_wlan` already did.
+- **The audit log can tie a confirmed delete to its preview, on the right
+  controller.** The scrubber redacts every key containing `token`, so the
+  preview's `result.token` and the confirm's `args.token` were both `***`
+  with nothing linking them, and `confirm_destructive_action` takes no
+  `controller` argument, so its event said `default` whatever the queued
+  action targeted. The preview envelope now carries `preview_id` (the first
+  eight characters of the token, not enough to confirm with), and the confirm
+  tool annotates its own event with the same `preview_id`, the queued
+  `action`, and the pending action's controller via a new
+  `mcp_unifi.modules._audit.annotate_audit` hook. `mcp-unifi-replay` now
+  treats a tool's `{"error": ...}` envelope as a failure instead of counting
+  it as success; replaying a confirm with a scrubbed token used to report
+  success while nothing was deleted.
+
+### Fixed
+
+- **`set_port_state` no longer wipes a port's other overrides on a real
+  controller.** The controller replaces `port_overrides` wholesale, and the
+  real backend built the new entry for the target port from only the fields
+  the caller passed. Disabling port 5 sent `{"port_idx": 5, "enable": false}`
+  and the port's profile, PoE mode and name reverted to defaults; a camera
+  port could change VLANs on a disable/enable. The entry now starts from the
+  port's existing override. The stub already merged, which is why the suite
+  did not catch it; the regression test captures the real PUT body.
+- **A connection dropped mid-request no longer re-sends a write.**
+  `request_with_retry` retried once on `RemoteProtocolError` for every verb,
+  and that error means the request was already sent: a `POST` the controller
+  had accepted was sent again (duplicate VLAN, rule, or port forward) and a
+  `DELETE` was reported failed on the retry's 404 after it had succeeded.
+  `RemoteProtocolError` is retried for `GET` only; `ConnectError` (nothing
+  sent) is still retried for every verb.
+- **Composite tools return the standard error envelope on an unknown
+  controller.** `create_iot_network`, `create_guest_network`, and
+  `provision_homelab_service` resolved the backend outside their `try`, so a
+  typo in `controller` raised out of the tool instead of returning
+  `{"error": ..., "stub_mode": ...}` like every other tool.
+
 - **Resource ids are validated as single URL path segments before they reach
   the gateway.** Every Protect, Access, and Network client method that puts a
   caller-supplied id into a URL path or query string now routes it through

--- a/src/mcp_unifi/backends.py
+++ b/src/mcp_unifi/backends.py
@@ -507,7 +507,12 @@ class RealBackend:
         if not device_id:
             raise UniFiError(f"device {device_mac} has no _id")
         existing = list(target.get("port_overrides") or [])
-        override: dict[str, Any] = {"port_idx": port_idx}
+        # The controller replaces port_overrides wholesale, so the new entry
+        # for this port must start from the current one or every other field
+        # on the same port (profile, PoE mode, name) silently reverts.
+        current = next((o for o in existing if o.get("port_idx") == port_idx), None)
+        override: dict[str, Any] = dict(current) if current else {}
+        override["port_idx"] = port_idx
         if enable is not None:
             override["enable"] = enable
         if poe_mode:

--- a/src/mcp_unifi/cli/replay.py
+++ b/src/mcp_unifi/cli/replay.py
@@ -82,6 +82,28 @@ async def _call_tool(server: Any, name: str, args: dict[str, Any]) -> Any:
     return await server.call_tool(name, args)
 
 
+def _error_envelope(result: Any) -> str | None:
+    """Return the tool's error message when it answered with an error envelope.
+
+    Tools do not raise on a bad request; they return ``{"error": ...}`` as a
+    JSON string. A replay that only catches exceptions counts every such
+    answer as success, which is how a replayed ``confirm_destructive_action``
+    with a scrubbed token reported success while nothing was deleted.
+    """
+    payload: Any = result
+    content = getattr(result, "content", None)
+    if content:
+        text = getattr(content[0], "text", None)
+        if isinstance(text, str):
+            try:
+                payload = json.loads(text)
+            except ValueError:
+                return None
+    if isinstance(payload, dict) and payload.get("error"):
+        return str(payload["error"])
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Replay loop
 # ---------------------------------------------------------------------------
@@ -143,13 +165,18 @@ async def replay_events(
             )
             continue
         try:
-            await _call_tool(srv, event.tool, dict(event.args))
+            outcome = await _call_tool(srv, event.tool, dict(event.args))
+            envelope_error = _error_envelope(outcome)
             results.append(
                 ReplayResult(
                     tool=event.tool,
                     controller=event.controller,
-                    success=True,
-                    error=None,
+                    success=envelope_error is None,
+                    error=(
+                        None
+                        if envelope_error is None
+                        else f"tool returned an error envelope: {envelope_error}"
+                    ),
                 )
             )
         except Exception as exc:  # we want every failure surfaced, not just UniFiError

--- a/src/mcp_unifi/clients/retry.py
+++ b/src/mcp_unifi/clients/retry.py
@@ -56,8 +56,12 @@ async def request_with_retry(
     """Issue an HTTP request, retrying only transient, safe-to-repeat failures.
 
     Retries applied:
-      * One retry on ``ConnectError`` / ``RemoteProtocolError`` (network blip),
-        matching every client's original single-retry behaviour.
+      * One retry on ``ConnectError`` for every verb: nothing reached the
+        controller, so repeating is safe.
+      * One retry on ``RemoteProtocolError`` for ``GET`` only. That error means
+        the connection dropped after the request was sent, so the controller
+        may already have applied a write; replaying a ``POST`` would create a
+        duplicate and replaying a ``DELETE`` reports a false failure.
       * Up to :data:`MAX_5XX_RETRIES` extra attempts on a 5xx response, but ONLY
         for idempotent ``GET`` requests, with exponential backoff. Non-GET verbs
         return their 5xx response immediately (the caller raises) so a write is
@@ -89,7 +93,7 @@ async def request_with_retry(
     while True:
         try:
             resp = await client.request(method, url, json=json)
-        except (httpx.ConnectError, httpx.RemoteProtocolError) as exc:
+        except httpx.ConnectError as exc:
             if not connect_retried:
                 connect_retried = True
                 logger.warning(
@@ -98,6 +102,21 @@ async def request_with_retry(
                     extra={"method": method, "url": url, "error": str(exc)},
                 )
                 continue
+            raise error_cls(f"{service} connection failed: {exc}") from exc
+        except httpx.RemoteProtocolError as exc:
+            if method.upper() == "GET" and not connect_retried:
+                connect_retried = True
+                logger.warning(
+                    "%s connection dropped mid-request, retrying idempotent read once",
+                    service,
+                    extra={"method": method, "url": url, "error": str(exc)},
+                )
+                continue
+            if method.upper() != "GET":
+                raise error_cls(
+                    f"{service} connection dropped after {method} was sent; not retried "
+                    f"because the controller may already have applied it: {exc}"
+                ) from exc
             raise error_cls(f"{service} connection failed: {exc}") from exc
         except httpx.HTTPError as exc:
             raise error_cls(f"{service} transport error: {exc}") from exc

--- a/src/mcp_unifi/modules/_audit.py
+++ b/src/mcp_unifi/modules/_audit.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from functools import wraps
 from typing import Any, ParamSpec, TypeVar
 
@@ -108,6 +109,31 @@ def tool_mutates(tool_name: str) -> bool | None:
 def classified_tools() -> dict[str, bool]:
     """Return a copy of the whole ``{tool_name: mutates}`` registry."""
     return dict(_CLASSIFICATION)
+
+
+_ANNOTATIONS: ContextVar[dict[str, Any] | None] = ContextVar(
+    "mcp_unifi_audit_annotations", default=None
+)
+
+
+def annotate_audit(*, controller: str | None = None, **fields: Any) -> None:
+    """Correct or enrich the audit event for the tool call in progress.
+
+    The decorator reads ``controller`` from the tool's kwargs, which is right
+    for every tool that takes one. ``confirm_destructive_action`` takes only a
+    token, so its event said ``default`` no matter which controller the queued
+    action targeted. A tool body calls this with the controller it actually
+    resolved, plus any non-secret fields that belong in ``args`` (a
+    ``preview_id`` that links a confirm to its preview, the queued ``action``).
+    Values here go through the same scrub as kwargs, so a sensitive key is
+    still redacted. No-op outside an audited call.
+    """
+    current = _ANNOTATIONS.get()
+    if current is None:
+        return
+    if controller is not None:
+        current["controller"] = controller
+    current.setdefault("args", {}).update(fields)
 
 
 def _current_client_id() -> str | None:
@@ -186,6 +212,13 @@ def audited(
             controller = str(kwargs.get("controller", "default"))
             client_id = _current_client_id()
             log = audit.get_audit_log()
+            annotations: dict[str, Any] = {}
+            annotations_token = _ANNOTATIONS.set(annotations)
+
+            def _apply_annotations() -> None:
+                nonlocal controller
+                controller = str(annotations.get("controller", controller))
+                audit_args.update(annotations.get("args", {}))
 
             # The span wraps the audit emit as well as the tool body, so its
             # duration is the full cost of serving the call rather than just
@@ -202,6 +235,8 @@ def audited(
                 try:
                     result = await fn(*args, **kwargs)
                 except Exception as exc:
+                    _ANNOTATIONS.reset(annotations_token)
+                    _apply_annotations()
                     latency_ms = (time.perf_counter() - start) * 1000.0
                     span.record_error(exc)
                     await log.emit(
@@ -216,6 +251,8 @@ def audited(
                     )
                     raise
 
+                _ANNOTATIONS.reset(annotations_token)
+                _apply_annotations()
                 latency_ms = (time.perf_counter() - start) * 1000.0
                 span.set(telemetry.ATTR_OUTCOME, telemetry.OUTCOME_OK)
                 await log.emit(
@@ -236,6 +273,7 @@ def audited(
 
 __all__ = [
     "ToolClassificationConflictError",
+    "annotate_audit",
     "audited",
     "classified_tools",
     "tool_mutates",

--- a/src/mcp_unifi/modules/network/_pending.py
+++ b/src/mcp_unifi/modules/network/_pending.py
@@ -186,6 +186,17 @@ def reset_pending_actions(ttl_seconds: float = TOKEN_TTL_SECONDS) -> PendingActi
     return _REGISTRY
 
 
+def preview_id(token: str) -> str:
+    """Non-secret correlation id for a preview token: its first 8 characters.
+
+    The audit scrubber redacts every key containing ``token``, so the preview
+    event's ``result.token`` and the confirm event's ``args.token`` are both
+    written as ``***`` and nothing in the log links the two halves. Eight hex
+    characters of a UUID4 identify the pair without being enough to confirm.
+    """
+    return token[:8]
+
+
 def build_preview_envelope(pending: PendingAction) -> dict[str, Any]:
     """Build the JSON-serialisable preview envelope returned by delete tools.
 
@@ -193,6 +204,7 @@ def build_preview_envelope(pending: PendingAction) -> dict[str, Any]:
     confirm tool can document the contract in one place.
     """
     return {
+        "preview_id": preview_id(pending.token),
         "preview": True,
         "action": pending.action,
         "controller": pending.controller,
@@ -209,5 +221,6 @@ __all__ = [
     "PendingActionsRegistry",
     "build_preview_envelope",
     "get_pending_actions",
+    "preview_id",
     "reset_pending_actions",
 ]

--- a/src/mcp_unifi/modules/network/composites.py
+++ b/src/mcp_unifi/modules/network/composites.py
@@ -210,7 +210,10 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
 
-        backend = resolve_backend(registry, controller)
+        try:
+            backend = resolve_backend(registry, controller)
+        except UniFiError as exc:
+            return err(str(exc))
         created: dict[str, Any] = {
             "network": None,
             "wlan": None,
@@ -401,7 +404,10 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
 
-        backend = resolve_backend(registry, controller)
+        try:
+            backend = resolve_backend(registry, controller)
+        except UniFiError as exc:
+            return err(str(exc))
         created: dict[str, Any] = {
             "lease": None,
             "firewall_rule": None,
@@ -657,7 +663,10 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 }
             )
 
-        backend = resolve_backend(registry, controller)
+        try:
+            backend = resolve_backend(registry, controller)
+        except UniFiError as exc:
+            return err(str(exc))
         created: dict[str, Any] = {
             "network": None,
             "wlan": None,

--- a/src/mcp_unifi/modules/network/confirm.py
+++ b/src/mcp_unifi/modules/network/confirm.py
@@ -11,10 +11,13 @@ Side effects:
   (a ``{"deleted": true, "<id>_id": "..."}`` envelope or an upstream error).
 * On expired / unknown token: returns the standard error envelope.
 
-The audit decorator captures both halves: the preview emits a
-``delete_<resource>`` event with the resolved ``_id`` and the freshly-minted
-token reference; the confirm emits a ``confirm_destructive_action`` event
-with the token (which lets a replay tool stitch the two halves together).
+The audit decorator captures both halves. The token itself is scrubbed from
+both events (any key containing ``token`` is a secret to the audit log), so the
+link between them is ``preview_id``: the preview envelope carries it, and this
+tool annotates its own event with the same value plus the queued ``action`` and
+the controller the pending action actually targets. Without that annotation
+the confirm event said ``controller: default`` regardless, because this tool
+takes no ``controller`` argument for the decorator to read.
 """
 
 from __future__ import annotations
@@ -24,9 +27,9 @@ from typing import TYPE_CHECKING
 
 from mcp_unifi.annotations import DESTRUCTIVE_ONCE
 from mcp_unifi.clients.unifi import UniFiError
-from mcp_unifi.modules._audit import audited
+from mcp_unifi.modules._audit import annotate_audit, audited
 from mcp_unifi.modules.network._common import make_err
-from mcp_unifi.modules.network._pending import get_pending_actions
+from mcp_unifi.modules.network._pending import get_pending_actions, preview_id
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -69,6 +72,7 @@ def register(mcp: FastMCP, settings: Settings, _registry: ControllerRegistry) ->
             standard error envelope (``{"error": "...", "stub_mode": bool}``)
             for unknown, used, or expired tokens.
         """
+        annotate_audit(preview_id=preview_id(token))
         pending = get_pending_actions().pop(token)
         if pending is None:
             return err(
@@ -76,6 +80,7 @@ def register(mcp: FastMCP, settings: Settings, _registry: ControllerRegistry) ->
                 "expire 5 minutes after issuance; re-invoke the original "
                 "destructive tool to get a fresh token."
             )
+        annotate_audit(controller=pending.controller, action=pending.action)
         try:
             return await pending.executor()
         except UniFiError as exc:

--- a/src/mcp_unifi/modules/network/vlans.py
+++ b/src/mcp_unifi/modules/network/vlans.py
@@ -299,7 +299,7 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 {
                     "dry_run": True,
                     "controller": controller,
-                    "would_update": {"network_id": network_id, "patch": updates},
+                    "would_update": {"network_id": network_id, "patch": redact(updates)},
                     "summary": f"Would update VLAN {network_id} ({len(updates)} field(s))",
                 }
             )
@@ -318,7 +318,10 @@ def register(mcp: FastMCP, settings: Settings, registry: ControllerRegistry) -> 
                 {
                     "network_id": network_id,
                     "verification": verification,
-                    "network": record,
+                    # Network records carry VPN key material (IPsec PSK,
+                    # WireGuard private key, RADIUS secret). The read path
+                    # redacts; the write path must too.
+                    "network": redact(record),
                 }
             )
         except UniFiError as exc:

--- a/tests/network/test_composites.py
+++ b/tests/network/test_composites.py
@@ -847,3 +847,54 @@ async def test_real_guest_network_rollback_partial_redacts_passphrase(
     assert result["partial"]["wlan"]["x_passphrase"] == "[REDACTED]"
     assert GUEST_PSK not in json.dumps(result)
     assert any(a.get("wlan") == "wlan-id" for a in result["rolled_back"])
+
+
+# ---------------------------------------------------------------------------
+# Unknown controller returns the envelope, never raises
+# (review 2026-09-08, finding 6)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_iot_network_unknown_controller_returns_envelope(
+    stub_server: FastMCP,
+) -> None:
+    result = await _call(
+        stub_server,
+        "create_iot_network",
+        {"name": "IoT", "vlan_id": 21, "passphrase": "iot-pass-1234", "controller": "nope"},
+    )
+    assert "Unknown controller" in result["error"]
+
+
+async def test_create_guest_network_unknown_controller_returns_envelope(
+    stub_server: FastMCP,
+) -> None:
+    result = await _call(
+        stub_server,
+        "create_guest_network",
+        {
+            "name": "Guest",
+            "ssid": "Guest",
+            "vlan_id": 22,
+            "passphrase": "guest-pass-1234",
+            "controller": "nope",
+        },
+    )
+    assert "Unknown controller" in result["error"]
+
+
+async def test_provision_homelab_service_unknown_controller_returns_envelope(
+    stub_server: FastMCP,
+) -> None:
+    result = await _call(
+        stub_server,
+        "provision_homelab_service",
+        {
+            "name": "svc",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "ip": "10.0.1.50",
+            "network_id": "x",
+            "controller": "nope",
+        },
+    )
+    assert "Unknown controller" in result["error"]

--- a/tests/network/test_devices.py
+++ b/tests/network/test_devices.py
@@ -719,3 +719,59 @@ async def test_set_radio_tx_power_redacts_radio_table_secrets(
     assert applied["after"]["x_vwirekey"] == "[REDACTED]"
     assert "do-not-leak" not in json.dumps(applied)
     assert applied["after"]["tx_power_mode"] == "low"
+
+
+@respx.mock
+async def test_real_set_port_state_keeps_other_fields_on_same_port(real_server: FastMCP) -> None:
+    """The controller replaces port_overrides wholesale. Changing one field on
+    port 5 must send port 5's existing profile, PoE mode and name back with it,
+    or they revert to defaults (a camera port could jump VLANs on a disable)."""
+    respx.get(f"{BASE}/stat/device").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "_id": "switch-1",
+                        "mac": "f4:e2:c6:00:00:03",
+                        "port_overrides": [
+                            {"port_idx": 6, "portconf_id": "prof-ap"},
+                            {
+                                "port_idx": 5,
+                                "portconf_id": "prof-cam",
+                                "poe_mode": "auto",
+                                "name": "cam-front",
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+    )
+    captured: dict[str, Any] = {}
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"_id": "switch-1", "port_overrides": captured["body"]["port_overrides"]}]
+            },
+        )
+
+    respx.put(f"{BASE}/rest/device/switch-1").mock(side_effect=capture)
+    await _call(
+        real_server,
+        "set_port_state",
+        {"device_mac": "f4:e2:c6:00:00:03", "port_idx": 5, "enable": False},
+    )
+    overrides = {o["port_idx"]: o for o in captured["body"]["port_overrides"]}
+    assert overrides[5] == {
+        "port_idx": 5,
+        "portconf_id": "prof-cam",
+        "poe_mode": "auto",
+        "name": "cam-front",
+        "enable": False,
+    }
+    assert overrides[6] == {"port_idx": 6, "portconf_id": "prof-ap"}
+    assert len(captured["body"]["port_overrides"]) == 2

--- a/tests/network/test_vlans.py
+++ b/tests/network/test_vlans.py
@@ -308,3 +308,40 @@ async def test_get_network_details_redacts_every_section(
     assert result["vpn"]["radiusprofile_id"] == "6501aaaabbbbccccdddd0001"
     assert result["vpn"]["vpn_type"] == "ipsec-vpn"
     assert result["network"]["name"] == "Site-to-Site"
+
+
+# ---------------------------------------------------------------------------
+# Redaction on the write path (review 2026-09-08, finding 2)
+# ---------------------------------------------------------------------------
+
+
+async def test_update_vlan_redacts_vpn_secrets(stub_server: FastMCP, stub_state: StubState) -> None:
+    """update_vlan re-reads the record after writing; that record carries VPN
+    key material and must come back redacted like list_networks does."""
+    net_id = stub_state.list_networks()[0]["_id"]
+    result = await _call(
+        stub_server,
+        "update_vlan",
+        {"network_id": net_id, "updates": {"x_ipsec_pre_shared_key": "vpn-psk-secret-123"}},
+    )
+    assert result["network"]["x_ipsec_pre_shared_key"] == "[REDACTED]"
+    assert "vpn-psk-secret-123" not in json.dumps(result)
+
+
+async def test_update_vlan_dry_run_redacts_patch(
+    stub_server: FastMCP, stub_state: StubState
+) -> None:
+    net_id = stub_state.list_networks()[0]["_id"]
+    result = await _call(
+        stub_server,
+        "update_vlan",
+        {
+            "network_id": net_id,
+            "updates": {"x_ipsec_pre_shared_key": "psk2", "name": "Renamed"},
+            "dry_run": True,
+        },
+    )
+    assert result["dry_run"] is True
+    assert result["would_update"]["patch"]["x_ipsec_pre_shared_key"] == "[REDACTED]"
+    assert result["would_update"]["patch"]["name"] == "Renamed"
+    assert "psk2" not in json.dumps(result)

--- a/tests/test_audit_integration.py
+++ b/tests/test_audit_integration.py
@@ -237,3 +237,76 @@ async def test_sequence_of_tool_calls_produces_one_event_per_call(
     # The dry-run call must be flagged distinctly.
     assert events[3]["args"]["dry_run"] is True
     assert events[3]["result"]["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Confirm events name their controller and link to their preview
+# (review 2026-09-08, finding 5)
+# ---------------------------------------------------------------------------
+
+
+async def test_annotate_audit_overrides_controller_and_adds_args(
+    file_sink_audit_log: tuple[Path, AuditLog],
+) -> None:
+    from mcp_unifi.modules._audit import annotate_audit
+
+    log_path, _ = file_sink_audit_log
+
+    @audited("synthetic_annotated_tool", mutates=True)
+    async def synthetic_annotated_tool(token: str) -> str:
+        annotate_audit(controller="office", preview_id="3f1a2b4c", action="delete_vlan")
+        return json.dumps({"deleted": True})
+
+    await synthetic_annotated_tool(token="3f1a2b4c-secret-rest")
+
+    ev = _read_events(log_path)[0]
+    assert ev["controller"] == "office"
+    assert ev["args"]["preview_id"] == "3f1a2b4c"
+    assert ev["args"]["action"] == "delete_vlan"
+    assert ev["args"]["token"] == REDACTED
+
+
+async def test_annotate_audit_survives_a_raising_tool(
+    file_sink_audit_log: tuple[Path, AuditLog],
+) -> None:
+    from mcp_unifi.modules._audit import annotate_audit
+
+    log_path, _ = file_sink_audit_log
+
+    @audited("synthetic_annotated_raiser", mutates=True)
+    async def synthetic_annotated_raiser() -> str:
+        annotate_audit(controller="office")
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        await synthetic_annotated_raiser()
+
+    ev = _read_events(log_path)[0]
+    assert ev["success"] is False
+    assert ev["controller"] == "office"
+
+
+async def test_confirm_event_links_to_preview_without_the_token(
+    stub_server: FastMCP,
+    file_sink_audit_log: tuple[Path, AuditLog],
+) -> None:
+    log_path, _ = file_sink_audit_log
+    created = await _call(
+        stub_server, "create_vlan", {"name": "Doomed", "vlan_id": 72, "subnet": "10.0.72.0/24"}
+    )
+    preview = await _call(stub_server, "delete_vlan", {"network_id": created["_id"]})
+    assert preview["preview_id"] == preview["token"][:8]
+    await _call(stub_server, "confirm_destructive_action", {"token": preview["token"]})
+
+    events = {ev["tool"]: ev for ev in _read_events(log_path)}
+    preview_ev = events["delete_vlan"]
+    confirm_ev = events["confirm_destructive_action"]
+    # The token stays a secret in both halves...
+    assert preview_ev["result"]["token"] == REDACTED
+    assert confirm_ev["args"]["token"] == REDACTED
+    # ...and preview_id is the link between them.
+    assert preview_ev["result"]["preview_id"] == preview["preview_id"]
+    assert confirm_ev["args"]["preview_id"] == preview["preview_id"]
+    assert confirm_ev["args"]["action"] == "delete_vlan"
+    assert confirm_ev["controller"] == preview_ev["controller"]
+    assert confirm_ev["result"]["deleted"] is True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -306,3 +306,57 @@ async def test_delete_firewall_rule_rejects_empty_id(client: UniFiClient) -> Non
     with pytest.raises(UniFiError):
         await client.delete_firewall_rule("")
     assert not escaped.called
+
+
+# ---------------------------------------------------------------------------
+# RemoteProtocolError: the connection dropped AFTER the request was sent
+# (review 2026-09-08, finding 4)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_remote_protocol_error_retried_once_for_get(client: UniFiClient) -> None:
+    route = respx.get(f"{BASE}/stat/device").mock(
+        side_effect=[httpx.RemoteProtocolError("closed"), httpx.Response(200, json={"data": []})]
+    )
+    assert await client.list_devices() == []
+    assert route.call_count == 2
+
+
+@respx.mock
+async def test_remote_protocol_error_not_retried_for_post(client: UniFiClient) -> None:
+    """The controller may have committed the write before the connection
+    dropped; sending it again would create a duplicate."""
+    route = respx.post(f"{BASE}/rest/networkconf").mock(
+        side_effect=[
+            httpx.RemoteProtocolError("closed"),
+            httpx.Response(200, json={"data": [{"_id": "n-new"}]}),
+        ]
+    )
+    with pytest.raises(UniFiError) as exc:
+        await client.create_network({"name": "Dup", "vlan": 70})
+    assert route.call_count == 1
+    assert "not retried" in str(exc.value)
+
+
+@respx.mock
+async def test_remote_protocol_error_not_retried_for_delete(client: UniFiClient) -> None:
+    route = respx.delete(f"{BASE}/rest/networkconf/n-1").mock(
+        side_effect=[httpx.RemoteProtocolError("closed"), httpx.Response(404)]
+    )
+    with pytest.raises(UniFiError):
+        await client.delete_network("n-1")
+    assert route.call_count == 1
+
+
+@respx.mock
+async def test_connect_error_still_retried_for_post(client: UniFiClient) -> None:
+    """ConnectError means nothing was sent, so a write is safe to repeat."""
+    route = respx.post(f"{BASE}/rest/networkconf").mock(
+        side_effect=[
+            httpx.ConnectError("nope"),
+            httpx.Response(200, json={"data": [{"_id": "n-new"}]}),
+        ]
+    )
+    assert (await client.create_network({"name": "Once", "vlan": 71}))["_id"] == "n-new"
+    assert route.call_count == 2

--- a/tests/test_replay_cli.py
+++ b/tests/test_replay_cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -286,3 +287,37 @@ def test_main_invalid_jsonl_returns_2(tmp_path: Path, capsys: pytest.CaptureFixt
     log.write_text("{not json\n", encoding="utf-8")
     rc = replay_mod.main([str(log)])
     assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# An error envelope is a failure, not a success (review 2026-09-08, finding 5)
+# ---------------------------------------------------------------------------
+
+
+class _EnvelopeServer:
+    """Answers like a real tool: no exception, an ``{"error": ...}`` envelope."""
+
+    def __init__(self, *, as_text: bool) -> None:
+        self._as_text = as_text
+
+    async def call_tool(self, name: str, args: dict[str, Any]) -> Any:
+        payload = {"error": "unknown or expired token", "stub_mode": True}
+        if not self._as_text:
+            return payload
+        # Shaped like FastMCP's ToolResult: .content[0].text holds the JSON.
+        return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+
+@pytest.mark.parametrize("as_text", [False, True])
+async def test_replay_treats_error_envelope_as_failure(as_text: bool) -> None:
+    results = await replay_mod.replay_events(
+        [_event("confirm_destructive_action", token="***")],
+        stub_mode=True,
+        target_controller=None,
+        i_mean_it=False,
+        server=_EnvelopeServer(as_text=as_text),
+    )
+    assert len(results) == 1
+    assert results[0].success is False
+    assert results[0].error is not None
+    assert "unknown or expired token" in results[0].error


### PR DESCRIPTION
Findings 2 through 6 of the 2026-09-08 review (`docs/audits/2026-09-08-overnight/mcp-unifi.md` in the workspace). Finding 1 was closed by #125 and #127. This is the "Not in this PR" list from #125.

## What was wrong, and what changed

**2. `update_vlan` returned VPN secrets (Medium).** `list_networks` and `get_network_details` redact `x_ipsec_pre_shared_key`, WireGuard `x_private_key`, RADIUS `x_secret`. `update_vlan` re-read the same record after writing and returned it raw, and its `dry_run` echoed the caller's patch raw. Toggling `enabled` on a site-to-site VPN put the PSK in the transcript. Both paths now go through `redact`, mirroring `update_wlan`.

**3. `set_port_state` wiped the port's other overrides (Medium).** The controller replaces `port_overrides` wholesale. The real backend built the target port's new entry from only the fields the caller passed, so `set_port_state(port_idx=5, enable=False)` sent `{"port_idx": 5, "enable": false}` and the port's profile, PoE mode and name reverted. The entry now starts from the existing override. The stub already merged, which is why the suite never saw it; the new test captures the real PUT body and asserts every prior field survives.

**4. A dropped connection re-sent writes (Medium).** `request_with_retry` retried once on `RemoteProtocolError` for every verb. That error means the request was sent and the connection closed afterward, so a `POST` the controller had accepted went out twice (duplicate VLAN, rule, port forward) and a `DELETE` reported failure on the retry's 404 after it had succeeded. `RemoteProtocolError` is retried for `GET` only, with an error message that says why a write was not retried. `ConnectError` (nothing sent) is still retried for every verb.

**5. Audit log could not link a confirm to its preview, and named the wrong controller (Medium).** The scrubber redacts every key containing `token`, so `result.token` on the preview and `args.token` on the confirm were both `***`. `confirm_destructive_action` takes only a token, so the decorator logged `controller: "default"` whatever the pending action targeted. Now:
- The preview envelope carries `preview_id`, the first 8 characters of the token. Not enough to confirm with; enough to match.
- New `annotate_audit(controller=..., **fields)` in `modules/_audit.py`: a ContextVar the decorator opens per call and reads on both the success and exception paths. The confirm tool annotates `preview_id` before the lookup (so a failed confirm is still matchable) and the pending action's `controller` and `action` after it.
- `mcp-unifi-replay` treats a tool's `{"error": ...}` envelope as a failure. It used to count it as success; a replayed confirm with a scrubbed token reported success while nothing was deleted.

**6. Composites raised on an unknown controller (Low).** `create_iot_network`, `create_guest_network`, `provision_homelab_service` resolved the backend outside their `try`. A typo in `controller` now returns the standard envelope like every other tool.

## Verified, including that the tests can fail

- `ruff check`, `ruff format --check`, `mypy --strict` over `src` and `evals`: clean. **1168 passed** (1153 before), coverage 88% (gate 80).
- Controls, each test file run alone with `src/` at `main`: both redaction tests fail; the port-override test fails; the POST and DELETE no-retry tests fail; all three audit-annotation tests fail; both replay envelope tests fail; all three composite envelope tests fail. The two guardrail tests (GET still retries `RemoteProtocolError`; `ConnectError` still retries a POST) pass both ways, as intended.
- Not run live: the port-override and retry behaviors are respx-captured request bodies and call counts, which is the exact thing the controller sees.

## Not a breaking change

No tool signature changes. `preview_id` is an added field on the preview envelope. `last_error`-style additions: none here. The `annotate_audit` hook is internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McxrpSs5mZjdZf52Fxr9wC
