### PR TITLE
release: bump server.json OCI identifier to 0.21.2

### DIFF
--- a/server.json
+++ b/server.json
@@ -12,7 +12,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.21.1",
+      "identifier": "ghcr.io/pete-builds/mcp-unifi:0.21.2",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:3714/mcp"


### PR DESCRIPTION
One line. The release guard checks seven surfaces; #131 moved six. The `v0.21.2` tag failed the guard on `server.json packages[0].identifier` before building, so nothing was published under it. After this merges the tag is re-pointed at the fixed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McxrpSs5mZjdZf52Fxr9wC